### PR TITLE
Issue#8 moved max recompute to algorithms

### DIFF
--- a/acnportal/acnsim/simulator.py
+++ b/acnportal/acnsim/simulator.py
@@ -21,14 +21,12 @@ class Simulator:
         events (EventQueue): Queue of events which will occur in the simulation.
         start (datetime): Date and time of the first period of the simulation.
         period (int): Length of each time interval in the simulation in minutes. Default: 1
-        max_recomp (int): Maximum number of periods between calling the scheduling algorithm even if no events occur.
-            If None, the scheduling algorithm is only called when an event occurs. Default: None.
         signals (Dict[str, ...]):
         store_schedule_history (bool): If True, store the scheduler output each time it is run. Note this can use lots
             of memory for long simulations.
     """
 
-    def __init__(self, network, scheduler, events, start, period=1, max_recomp=None, signals=None,
+    def __init__(self, network, scheduler, events, start, period=1, signals=None,
                  store_schedule_history=False, verbose=True):
         self.network = network
         self.scheduler = scheduler
@@ -36,7 +34,7 @@ class Simulator:
         self.event_queue = events
         self.start = start
         self.period = period
-        self.max_recompute = max_recomp
+        self.max_recompute = scheduler.max_recompute
         self.signals = signals
         self.verbose = verbose
 

--- a/acnportal/acnsim/tests/test_simulator.py
+++ b/acnportal/acnsim/tests/test_simulator.py
@@ -1,22 +1,15 @@
 from unittest import TestCase
 from unittest.mock import Mock, create_autospec
 
-import pandas as pd
 import numpy as np
-import os
 
 from acnportal.acnsim import Simulator
 from acnportal.acnsim.network import ChargingNetwork
-from acnportal.acnsim import acndata_events
-from acnportal.acnsim import sites
 from acnportal.algorithms import BaseAlgorithm
 from acnportal.acnsim.events import EventQueue, Event
 from datetime import datetime
 from acnportal.acnsim.models import EVSE
 
-import json
-import pytz
-from copy import deepcopy
 
 class TestSimulator(TestCase):
     def setUp(self):
@@ -29,6 +22,7 @@ class TestSimulator(TestCase):
         evse3 = EVSE('PS-003', max_rate=32)
         network.register_evse(evse3, 240, 0)
         scheduler = create_autospec(BaseAlgorithm)
+        scheduler.max_recompute = None
         events = EventQueue(events=[Event(1), Event(2)])
         self.simulator = Simulator(network, scheduler, events, start)
 

--- a/acnportal/algorithms/base_algorithm.py
+++ b/acnportal/algorithms/base_algorithm.py
@@ -6,6 +6,7 @@ class BaseAlgorithm:
 
     def __init__(self):
         self._interface = None
+        self.max_recompute = None
 
     @property
     def interface(self):

--- a/acnportal/algorithms/base_algorithm.py
+++ b/acnportal/algorithms/base_algorithm.py
@@ -2,6 +2,10 @@ class BaseAlgorithm:
     """ Abstract base class meant to be inherited from to implement new algorithms.
 
     Subclassed must implement the schedule method.
+
+    Attributes:
+        max_recompute (int): Maximum number of periods between calling the scheduling algorithm even if no events occur.
+            If None, the scheduling algorithm is only called when an event occurs. Default: None.
     """
 
     def __init__(self):

--- a/acnportal/algorithms/sorted_algorithms.py
+++ b/acnportal/algorithms/sorted_algorithms.py
@@ -24,7 +24,7 @@ class SortedSchedulingAlgo(BaseAlgorithm):
     def __init__(self, sort_fn):
         super().__init__()
         self._sort_fn = sort_fn
-        self.max_recompute = 1
+        self.max_recompute = 1  # Call algorithm each period since it only returns a rate for the next period.
 
     def schedule(self, active_evs):
         """ Schedule EVs by first sorting them by sort_fn, then allocating them their maximum feasible rate.

--- a/acnportal/algorithms/sorted_algorithms.py
+++ b/acnportal/algorithms/sorted_algorithms.py
@@ -1,4 +1,3 @@
-import math
 from collections import deque
 from copy import copy
 
@@ -25,6 +24,7 @@ class SortedSchedulingAlgo(BaseAlgorithm):
     def __init__(self, sort_fn):
         super().__init__()
         self._sort_fn = sort_fn
+        self.max_recompute = 1
 
     def schedule(self, active_evs):
         """ Schedule EVs by first sorting them by sort_fn, then allocating them their maximum feasible rate.

--- a/acnportal/algorithms/uncontrolled_charging.py
+++ b/acnportal/algorithms/uncontrolled_charging.py
@@ -10,6 +10,11 @@ class UncontrolledCharging(BaseAlgorithm):
     All EVs will be charged as quickly as possible according to their maximum charging rate and their battery dynamics.
 
     """
+    def __init__(self):
+        super().__init__()
+        self.max_recompute = 1
+
+
     def schedule(self, active_evs):
         """ Schedule each EV to charge as quickly as possible ignoring all infrastructure constraints.
 

--- a/acnportal/algorithms/uncontrolled_charging.py
+++ b/acnportal/algorithms/uncontrolled_charging.py
@@ -12,8 +12,7 @@ class UncontrolledCharging(BaseAlgorithm):
     """
     def __init__(self):
         super().__init__()
-        self.max_recompute = 1
-
+        self.max_recompute = 1  # Call algorithm each period since it only returns a rate for the next period.
 
     def schedule(self, active_evs):
         """ Schedule each EV to charge as quickly as possible ignoring all infrastructure constraints.

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2,13 +2,10 @@ from unittest import TestCase
 
 from acnportal import acnsim
 from acnportal.acnsim import Simulator
-from acnportal.acnsim.network import ChargingNetwork
 from acnportal.acnsim import acndata_events
 from acnportal.acnsim import sites
 from acnportal.algorithms import BaseAlgorithm
-from acnportal.acnsim.events import EventQueue, Event
 from datetime import datetime
-from acnportal.acnsim.models import EVSE
 
 import pytz
 import numpy as np
@@ -16,11 +13,13 @@ import os
 import json
 from copy import deepcopy
 
+
 class EarliestDeadlineFirstAlgo(BaseAlgorithm):
     ''' See EarliestDeadlineFirstAlgo in tutorial 2. '''
     def __init__(self, increment=1):
         super().__init__()
         self._increment = increment
+        self.max_recompute = 1
 
     def schedule(self, active_evs):
         schedule = {ev.station_id: [0] for ev in active_evs}
@@ -60,7 +59,7 @@ class TestAnalysisFuncs(TestCase):
 
         sch = EarliestDeadlineFirstAlgo(increment=1)
 
-        self.sim = Simulator(deepcopy(cn), sch, deepcopy(events), start, period=period, max_recomp=1, verbose=False)
+        self.sim = Simulator(deepcopy(cn), sch, deepcopy(events), start, period=period, verbose=False)
         self.sim.run()
 
         with open(os.path.join(os.path.dirname(__file__), 'edf_algo_true_analysis_fields.json'), 'r') as infile:
@@ -123,7 +122,7 @@ class TestAnalysisFuncs(TestCase):
 
         sch = EarliestDeadlineFirstAlgo(increment=1)
 
-        self.sim = Simulator(deepcopy(cn), sch, deepcopy(events), start, period=period, max_recomp=1, verbose=False)
+        self.sim = Simulator(deepcopy(cn), sch, deepcopy(events), start, period=period, verbose=False)
         self.sim.run()
 
         with open(os.path.join(os.path.dirname(__file__), 'edf_algo_true_info_fields.json'), 'r') as infile:

--- a/tutorials/lesson1_running_an_experiment.ipynb
+++ b/tutorials/lesson1_running_an_experiment.ipynb
@@ -152,7 +152,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sim = acnsim.Simulator(cn, sch, events, start, period=period, max_recomp=1, verbose=False)"
+    "sim = acnsim.Simulator(cn, sch, events, start, period=period, verbose=False)"
    ]
   },
   {

--- a/tutorials/lesson1_running_an_experiment.py
+++ b/tutorials/lesson1_running_an_experiment.py
@@ -62,7 +62,7 @@ sch = algorithms.UncontrolledCharging()
 
 # -- Simulator ---------------------------------------------------------------------------------------------------------
 # We can now load the simulator enviroment with the network, scheduler, and events we have already defined.
-sim = acnsim.Simulator(cn, sch, events, start, period=period, max_recomp=1)
+sim = acnsim.Simulator(cn, sch, events, start, period=period)
 
 # To execute the simulation we simply call the run() function.
 sim.run()

--- a/tutorials/lesson2_custom_algorithms.py
+++ b/tutorials/lesson2_custom_algorithms.py
@@ -40,6 +40,7 @@ class EarliestDeadlineFirstAlgo(BaseAlgorithm):
     def __init__(self, increment=1):
         super().__init__()
         self._increment = increment
+        self.max_recompute = 1
 
     def schedule(self, active_evs):
         """ Schedule EVs by first sorting them by departure time, then allocating them their maximum feasible rate.

--- a/tutorials/lesson2_custom_algorithms.py
+++ b/tutorials/lesson2_custom_algorithms.py
@@ -115,11 +115,11 @@ sch = EarliestDeadlineFirstAlgo(increment=1)
 sch2 = algorithms.SortedSchedulingAlgo(algorithms.earliest_deadline_first)
 
 # -- Simulator ---------------------------------------------------------------------------------------------------------
-sim = acnsim.Simulator(deepcopy(cn), sch, deepcopy(events), start, period=period, max_recomp=1, verbose=True)
+sim = acnsim.Simulator(deepcopy(cn), sch, deepcopy(events), start, period=period, verbose=True)
 sim.run()
 
 # For comparison we will also run the builtin earliest deadline first algorithm
-sim2 = acnsim.Simulator(deepcopy(cn), sch2, deepcopy(events), start, period=period, max_recomp=1)
+sim2 = acnsim.Simulator(deepcopy(cn), sch2, deepcopy(events), start, period=period)
 sim2.run()
 
 # -- Analysis ----------------------------------------------------------------------------------------------------------

--- a/tutorials/lesson2_implementing_a_custom_algorithm.ipynb
+++ b/tutorials/lesson2_implementing_a_custom_algorithm.ipynb
@@ -88,6 +88,7 @@
     "    def __init__(self, increment=1):\n",
     "        super().__init__()\n",
     "        self._increment = increment\n",
+    "        self.max_recompute = 1\n",
     "\n",
     "    def schedule(self, active_evs):\n",
     "        schedule = {ev.station_id: [0] for ev in active_evs}\n",

--- a/tutorials/lesson2_implementing_a_custom_algorithm.ipynb
+++ b/tutorials/lesson2_implementing_a_custom_algorithm.ipynb
@@ -197,7 +197,7 @@
    "outputs": [],
    "source": [
     "# -- Simulator ---------------------------------------------------------------------------------------------------------\n",
-    "sim = acnsim.Simulator(deepcopy(cn), sch, deepcopy(events), start, period=period, max_recomp=1, verbose=False)\n",
+    "sim = acnsim.Simulator(deepcopy(cn), sch, deepcopy(events), start, period=period, verbose=False)\n",
     "sim.run()"
    ]
   },
@@ -208,7 +208,7 @@
    "outputs": [],
    "source": [
     "# For comparison we will also run the builtin earliest deadline first algorithm\n",
-    "sim2 = acnsim.Simulator(deepcopy(cn), sch2, deepcopy(events), start, period=period, max_recomp=1, verbose=False)\n",
+    "sim2 = acnsim.Simulator(deepcopy(cn), sch2, deepcopy(events), start, period=period, verbose=False)\n",
     "sim2.run()"
    ]
   },


### PR DESCRIPTION
See Issue #8.

This branch moves the max_recompute variable from the Simulator to each algorithm. This was done because some algorithms require a certain recompute frequency. For example, most of the baseline algorithms only work with max_recompute of 1. 