### PR TITLE
fixed evse voltage dict bug and associated test

### DIFF
--- a/acnportal/acnsim/interface.py
+++ b/acnportal/acnsim/interface.py
@@ -122,7 +122,7 @@ class Interface:
             float: voltage of the EVSE. [V]
         """
 
-        return self._simulator.network.voltages[self._simulator.network.station_ids.index(station_id)]
+        return self._simulator.network.voltages[station_id]
 
     def remaining_amp_periods(self, ev):
         """ Return the EV's remaining demand in A*periods.

--- a/acnportal/acnsim/tests/test_interface.py
+++ b/acnportal/acnsim/tests/test_interface.py
@@ -43,11 +43,11 @@ class TestInterface(TestCase):
                 {'PS-001' : [1, 2], 'PS-002' : [3, 4, 5], 'PS-003' : [4, 5]})
 
     def test_is_feasible(self):
-        self.simulator.network = create_autospec(ChargingNetwork)
-        self.simulator.network.station_ids = ['PS-002', 'PS-001', 'PS-003']
+        # Mock network's is_feasible function to check its call signature later
+        self.network.is_feasible = create_autospec(self.network.is_feasible)
         _ = self.interface.is_feasible({'PS-001' : [1, 2], 'PS-002' : [4, 5]})
-        network_is_feasible_args = self.interface._simulator.network.is_feasible.call_args
+        network_is_feasible_args = self.network.is_feasible.call_args
         # Check that the call to the network's is_feasible method has the correct arguments
-        np.testing.assert_allclose(network_is_feasible_args[0][0], np.array([[4, 5], [1, 2], [0, 0]]))
+        np.testing.assert_allclose(network_is_feasible_args[0][0], np.array([[1, 2], [0, 0], [4, 5]]))
         # Network's is_feasible method has its second argument (linear) defaulting to False. Check this is the case.
         self.assertEqual(network_is_feasible_args[0][1], False)

--- a/acnportal/acnsim/tests/test_interface.py
+++ b/acnportal/acnsim/tests/test_interface.py
@@ -3,16 +3,22 @@ from unittest.mock import Mock, create_autospec, patch
 
 from acnportal.acnsim import Simulator, Interface, InvalidScheduleError
 from acnportal.acnsim.network import ChargingNetwork
-from acnportal.acnsim.models import EV
+from acnportal.acnsim.models import EV, EVSE
 
 import numpy as np
 
 class TestInterface(TestCase):
     def setUp(self):
         self.simulator = create_autospec(Simulator)
-        self.network = create_autospec(ChargingNetwork)
+        self.network = ChargingNetwork()
         self.simulator.network = self.network
         self.interface = Interface(self.simulator)
+        evse1 = EVSE('PS-001')
+        self.network.register_evse(evse1, 120, -30)
+        evse2 = EVSE('PS-002')
+        evse3 = EVSE('PS-003')
+        self.network.register_evse(evse3, 360, 150)
+        self.network.register_evse(evse2, 240, 90)
 
     def test_init(self):
         self.assertIs(self.interface._simulator, self.simulator)
@@ -26,9 +32,7 @@ class TestInterface(TestCase):
         self.assertEqual(self.interface.last_applied_pilot_signals, {})
 
     def test_evse_voltage(self):
-        self.network.station_ids = ['PS-002', 'PS-001', 'PS-003']
-        self.network.voltages = [120, 360, 240]
-        self.assertEqual(self.interface.evse_voltage('PS-001'), 360)
+        self.assertEqual(self.interface.evse_voltage('PS-002'), 240)
 
     def test_is_feasible_empty_schedule(self):
         self.assertTrue(self.interface.is_feasible({}))
@@ -39,9 +43,10 @@ class TestInterface(TestCase):
                 {'PS-001' : [1, 2], 'PS-002' : [3, 4, 5], 'PS-003' : [4, 5]})
 
     def test_is_feasible(self):
-        self.network.station_ids = ['PS-002', 'PS-001', 'PS-003']
+        self.simulator.network = create_autospec(ChargingNetwork)
+        self.simulator.network.station_ids = ['PS-002', 'PS-001', 'PS-003']
         _ = self.interface.is_feasible({'PS-001' : [1, 2], 'PS-002' : [4, 5]})
-        network_is_feasible_args = self.network.is_feasible.call_args
+        network_is_feasible_args = self.interface._simulator.network.is_feasible.call_args
         # Check that the call to the network's is_feasible method has the correct arguments
         np.testing.assert_allclose(network_is_feasible_args[0][0], np.array([[4, 5], [1, 2], [0, 0]]))
         # Network's is_feasible method has its second argument (linear) defaulting to False. Check this is the case.


### PR DESCRIPTION
evse_voltage in interface.py was behaving as if network.voltages returned an array, when it actually behaves as a dict. The tests did not account for this error due to incorrect mocking of the voltages. This pull req fixes the bug and the test.