### PR TITLE
fixed dimensionality bug in pilot_signals_as_df and charging_rates_as_df

### DIFF
--- a/acnportal/acnsim/simulator.py
+++ b/acnportal/acnsim/simulator.py
@@ -180,11 +180,11 @@ class Simulator:
         """ Return the charging rates as a pandas DataFrame, with EVSE id as columns
         and iteration as index.
         """
-        return pd.DataFrame(data=self.charging_rates, columns=self.network.station_ids)
+        return pd.DataFrame(data=self.charging_rates.T, columns=self.network.station_ids)
 
     def pilot_signals_as_df(self):
         """ Return the pilot signals as a pandas DataFrame """
-        return pd.DataFrame(data=self.pilot_signals, columns=self.network.station_ids)
+        return pd.DataFrame(data=self.pilot_signals.T, columns=self.network.station_ids)
 
     def index_of_evse(self, station_id):
         """ Return the numerical index of the EVSE given by station_id in the (ordered) dictionary

--- a/acnportal/acnsim/tests/test_simulator.py
+++ b/acnportal/acnsim/tests/test_simulator.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 from unittest.mock import Mock, create_autospec
 
 import numpy as np
+import pandas as pd
 
 from acnportal.acnsim import Simulator
 from acnportal.acnsim.network import ChargingNetwork
@@ -51,3 +52,17 @@ class TestSimulator(TestCase):
     def test_index_of_evse(self):
         idx = self.simulator.index_of_evse('PS-002')
         self.assertEqual(idx, 1)
+
+    def test_pilot_signals_as_df(self):
+        self.simulator.pilot_signals = np.array([[1, 2], [3, 4], [5, 6]])
+        outframe = self.simulator.pilot_signals_as_df()
+        pd.testing.assert_frame_equal(outframe,
+            pd.DataFrame(np.array([[1, 3, 5], [2, 4, 6]]),
+                columns=['PS-001', 'PS-002', 'PS-003']))
+
+    def test_charging_rates_as_df(self):
+        self.simulator.charging_rates = np.array([[1.1, 2.1], [3.1, 4.1], [5.1, 6.1]])
+        outframe = self.simulator.charging_rates_as_df()
+        pd.testing.assert_frame_equal(outframe,
+            pd.DataFrame(np.array([[1.1, 3.1, 5.1], [2.1, 4.1, 6.1]]),
+                columns=['PS-001', 'PS-002', 'PS-003']))


### PR DESCRIPTION
Fixed dimension mismatch in `charging_rates_as_df` and `pilot_signals_as_df`