### PR TITLE
Fix EV reset

### DIFF
--- a/acnportal/acnsim/models/battery.py
+++ b/acnportal/acnsim/models/battery.py
@@ -19,6 +19,7 @@ class Battery:
             raise ValueError('Initial Charge cannot be greater than capacity.')
         self._capacity = capacity
         self._current_charge = init_charge
+        self._init_charge = init_charge
         self._max_power = max_power
         self._current_charging_power = 0
 
@@ -64,8 +65,10 @@ class Battery:
         self._current_charging_power = charge_power
         return charge_power * 1000 / voltage
 
-    def reset(self, init_charge):
-        """ Reset battery to initial state.
+    def reset(self, init_charge=None):
+        """ Reset battery to initial state. If init_charge is not
+        given (is None), the battery is reset to its initial charge
+        on initialization.
 
         Args:
             init_charge (float): charge battery should be reset to. [acnsim units]
@@ -73,9 +76,12 @@ class Battery:
         Returns:
             None
         """
-        if init_charge > self._capacity:
-            raise ValueError('Initial Charge cannot be greater than capacity.')
-        self._current_charge = init_charge
+        if init_charge is None:
+            self.current_charge = self._init_charge
+        else:
+            if init_charge > self._capacity:
+                raise ValueError('Initial Charge cannot be greater than capacity.')
+            self._current_charge = init_charge
         self._current_charging_power = 0
 
 

--- a/acnportal/acnsim/models/battery.py
+++ b/acnportal/acnsim/models/battery.py
@@ -77,7 +77,7 @@ class Battery:
             None
         """
         if init_charge is None:
-            self.current_charge = self._init_charge
+            self._current_charge = self._init_charge
         else:
             if init_charge > self._capacity:
                 raise ValueError('Initial Charge cannot be greater than capacity.')

--- a/acnportal/acnsim/models/tests/test_EV.py
+++ b/acnportal/acnsim/models/tests/test_EV.py
@@ -25,8 +25,6 @@ class TestEV(TestCase):
         self.ev._battery.charge.assert_called_once()
 
     def test_reset(self):
-        self.ev._battery.reset = Mock()
-        self.ev._battery.reset = Mock()
         self.ev.reset()
         self.assertEqual(self.ev.energy_delivered, 0)
         self.ev._battery.reset.assert_called_once()

--- a/acnportal/acnsim/models/tests/test_battery.py
+++ b/acnportal/acnsim/models/tests/test_battery.py
@@ -7,7 +7,8 @@ from acnportal.acnsim.models import Battery, Linear2StageBattery
 
 class TestBatteryBase(TestCase):
     def setUp(self):
-        self.batt = Battery(100, 50, 32)
+        self.init_charge = 50
+        self.batt = Battery(100, self.init_charge, 32)
 
     def test_charge_negative_voltage(self):
         with self.assertRaises(ValueError):
@@ -16,6 +17,12 @@ class TestBatteryBase(TestCase):
     def test_charge_negative_period(self):
         with self.assertRaises(ValueError):
             self.batt.charge(32, 240, -5)
+
+    def test_valid_reset_default(self):
+        self.batt.charge(16, 240, 5)
+        self.batt.reset()
+        self.assertEqual(self.batt.current_charging_power, 0)
+        self.assertEqual(self.batt._current_charge, self.init_charge)
 
     def test_valid_reset(self):
         self.batt.charge(16, 240, 5)
@@ -30,7 +37,8 @@ class TestBatteryBase(TestCase):
 
 class TestBattery(TestBatteryBase):
     def setUp(self):
-        self.batt = Battery(100, 50, 7.68)
+        self.init_charge = 50
+        self.batt = Battery(100, self.init_charge, 7.68)
 
     def test_valid_charge(self):
         rate = self.batt.charge(16, 240, 5)
@@ -54,7 +62,9 @@ class TestBattery(TestBatteryBase):
 
 class TestLinear2StageBattery(TestBatteryBase):
     def setUp(self):
-        self.batt = Linear2StageBattery(100, 0, 7.68, 0)
+        self.init_charge = 0
+        self.batt = Linear2StageBattery(
+            100, self.init_charge, 7.68, 0)
 
     def test_valid_charge_no_noise_not_tail(self):
         self.batt = Linear2StageBattery(100, 0, 7.68, 0)


### PR DESCRIPTION
Fixes bug in `EV.reset()` function by making  `init_charge` input to `Battery.reset()` optional. `Battery.reset()` now resets to initial `Battery` charge on initialization by default.