### PR TITLE
Fix allowable pilot signals

### DIFF
--- a/acnportal/acnsim/interface.py
+++ b/acnportal/acnsim/interface.py
@@ -76,6 +76,8 @@ class Interface:
 
     def allowable_pilot_signals(self, station_id):
         """ Returns the allowable pilot signal levels for the specified EVSE.
+        One may assume an EVSE pilot signal of 0 is allowed regardless
+        of this function's return values.
 
         Args:
             station_id (str): The ID of the station for which the allowable rates should be returned.
@@ -86,11 +88,7 @@ class Interface:
                 the min and the max acceptable values. [A]
         """
         evse = self._simulator.network._EVSEs[station_id]
-        if evse.is_continuous:
-            rate_set = [evse.min_rate, evse.max_rate]
-        else:
-            rate_set = evse.allowable_rates
-        return evse.is_continuous, rate_set
+        return evse.is_continuous, evse.allowable_pilot_signals
 
     def max_pilot_signal(self, station_id):
         """ Returns the maximum allowable pilot signal level for the specified EVSE.

--- a/acnportal/acnsim/models/evse.py
+++ b/acnportal/acnsim/models/evse.py
@@ -81,6 +81,16 @@ class EVSE:
         """ Return pilot signal for the current time step. (float)"""
         return self._current_pilot
 
+    @property
+    def allowable_pilot_signals(self):
+        """ Returns the allowable pilot signal levels for this EVSE.
+
+        Returns:
+            list[float]: List of 2 values: the min and max
+                acceptable values.
+        """
+        return [self.min_rate, self.max_rate]
+
     def set_pilot(self, pilot, voltage, period):
         """ Apply a new pilot signal to the EVSE.
 
@@ -159,6 +169,16 @@ class DeadbandEVSE(EVSE):
         super().__init__(station_id, max_rate, min_rate)
         self._deadband_end = deadband_end
 
+    @property
+    def allowable_pilot_signals(self):
+        """ Returns the allowable pilot signal levels for this EVSE.
+
+        Returns:
+            list[float]: List of 2 values: the min and max
+                acceptable values.
+        """
+        return [self._deadband_end, self.max_rate]
+
     def _valid_rate(self, pilot, atol=1e-3):
         """ Overrides super class method. Disallows rates between 0 - 6 A as per the J1772 standard.
 
@@ -185,6 +205,15 @@ class FiniteRatesEVSE(EVSE):
         super().__init__(station_id, max(allowable_rates))
         self.allowable_rates = allowable_rates
         self.is_continuous = False
+
+    @property
+    def allowable_pilot_signals(self):
+        """ Returns the allowable pilot signal levels for this EVSE.
+
+        Returns:
+            list[float]: List of allowable pilot signals.
+        """
+        return self.allowable_rates
 
     def _valid_rate(self, pilot, atol=1e-3):
         """ Overrides super class method. Checks if pilot is close to being in the allowable set.

--- a/acnportal/acnsim/models/tests/test_EVSE.py
+++ b/acnportal/acnsim/models/tests/test_EVSE.py
@@ -9,6 +9,10 @@ class TestEVSE(TestCase):
     def setUp(self):
         self.evse = EVSE('0001')
 
+    def test_allowable_pilot_signals(self):
+        self.assertEqual(self.evse.allowable_pilot_signals,
+            [0, float('inf')])
+
     def test_plugin_unoccupied(self):
         ev = create_autospec(EV)
         self.evse.plugin(ev)
@@ -54,6 +58,10 @@ class TestDeadbandEVSE(TestEVSE):
     def setUp(self):
         self.evse = DeadbandEVSE('0001', 6, max_rate=8, min_rate=0)
 
+    def test_allowable_pilot_signals(self):
+        self.assertEqual(self.evse.allowable_pilot_signals,
+            [6, 8])
+
     def test_set_pilot_has_ev_invalid_rate(self):
         ev = create_autospec(EV)
         self.evse.plugin(ev)
@@ -68,6 +76,10 @@ class TestDeadbandEVSE(TestEVSE):
 class TestFiniteRatesEVSE(TestEVSE):
     def setUp(self):
         self.evse = FiniteRatesEVSE('0001', [0, 8, 16, 24, 32])
+
+    def test_allowable_pilot_signals(self):
+        self.assertEqual(self.evse.allowable_pilot_signals,
+            [0, 8, 16, 24, 32])
 
     def test_set_pilot_has_ev_invalid_rate(self):
         ev = create_autospec(EV)

--- a/acnportal/acnsim/tests/test_interface.py
+++ b/acnportal/acnsim/tests/test_interface.py
@@ -31,6 +31,12 @@ class TestInterface(TestCase):
         self.simulator.iteration = 1
         self.assertEqual(self.interface.last_applied_pilot_signals, {})
 
+    def test_allowable_pilot_signals(self):
+        self.assertEqual(
+            self.interface.allowable_pilot_signals('PS-001'),
+            (True, [0, float('inf')])
+        )
+
     def test_evse_voltage(self):
         self.assertEqual(self.interface.evse_voltage('PS-002'), 240)
 


### PR DESCRIPTION
Fixes lack of support for `DeadbandEVSE` in `Interface`'s `allowable_pilot_signals` function by:
- Moving logic for determining allowable set into the `EVSE`-like classes.
- Returning the deadband end as the minimum rate for `DeadbandEVSE`.

A pilot signal of 0 is implied to be allowed for all EVSEs. This is mentioned in the documentation for the `Interface`'s `allowable_pilot_signals` function.