### PR TITLE
Fix allowable_rates initialization in FiniteRatesEVSE.

### DIFF
--- a/acnportal/acnsim/models/evse.py
+++ b/acnportal/acnsim/models/evse.py
@@ -199,11 +199,15 @@ class FiniteRatesEVSE(EVSE):
 
     Attributes:
         allowable_rates (iterable): Iterable of rates which are allowed by the EVSE.
+            On initialization, allowable_rates is converted into a list of rates
+            in increasing order that includes 0 and contains no duplicate values.
 
     """
     def __init__(self, station_id, allowable_rates):
         super().__init__(station_id, max(allowable_rates))
-        self.allowable_rates = allowable_rates
+        allowable_rates = set(allowable_rates)
+        allowable_rates.add(0)
+        self.allowable_rates = sorted(list(allowable_rates))
         self.is_continuous = False
 
     @property

--- a/acnportal/acnsim/models/tests/test_EVSE.py
+++ b/acnportal/acnsim/models/tests/test_EVSE.py
@@ -76,24 +76,24 @@ class TestDeadbandEVSE(TestEVSE):
 class TestFiniteRatesEVSE(TestEVSE):
     def setUp(self):
         self.evse = FiniteRatesEVSE('0001', [0, 8, 16, 24, 32])
-        self.evse2 = FiniteRatesEVSE('0002', [32, 16, 8, 24, 0])
-        self.evse3 = FiniteRatesEVSE('0003', [0, 8, 8, 24, 16, 24, 32])
-        self.evse4 = FiniteRatesEVSE('0004', [8, 24, 16, 32])
 
     def test_allowable_pilot_signals(self):
         self.assertEqual(self.evse.allowable_pilot_signals,
             [0, 8, 16, 24, 32])
 
     def test_allowable_pilot_signals_unsorted(self):
-        self.assertEqual(self.evse2.allowable_pilot_signals,
+        evse2 = FiniteRatesEVSE('0002', [32, 16, 8, 24, 0])
+        self.assertEqual(evse2.allowable_pilot_signals,
             [0, 8, 16, 24, 32])
 
     def test_allowable_pilot_signals_duplicates(self):
-        self.assertEqual(self.evse3.allowable_pilot_signals,
+        evse3 = FiniteRatesEVSE('0003', [0, 8, 8, 24, 16, 24, 32])
+        self.assertEqual(evse3.allowable_pilot_signals,
             [0, 8, 16, 24, 32])
 
     def test_allowable_pilot_signals_no_zero(self):
-        self.assertEqual(self.evse4.allowable_pilot_signals,
+        evse4 = FiniteRatesEVSE('0004', [8, 24, 16, 32])
+        self.assertEqual(evse4.allowable_pilot_signals,
             [0, 8, 16, 24, 32])
 
     def test_set_pilot_has_ev_invalid_rate(self):

--- a/acnportal/acnsim/models/tests/test_EVSE.py
+++ b/acnportal/acnsim/models/tests/test_EVSE.py
@@ -76,9 +76,24 @@ class TestDeadbandEVSE(TestEVSE):
 class TestFiniteRatesEVSE(TestEVSE):
     def setUp(self):
         self.evse = FiniteRatesEVSE('0001', [0, 8, 16, 24, 32])
+        self.evse2 = FiniteRatesEVSE('0002', [32, 16, 8, 24, 0])
+        self.evse3 = FiniteRatesEVSE('0003', [0, 8, 8, 24, 16, 24, 32])
+        self.evse4 = FiniteRatesEVSE('0004', [8, 24, 16, 32])
 
     def test_allowable_pilot_signals(self):
         self.assertEqual(self.evse.allowable_pilot_signals,
+            [0, 8, 16, 24, 32])
+
+    def test_allowable_pilot_signals_unsorted(self):
+        self.assertEqual(self.evse2.allowable_pilot_signals,
+            [0, 8, 16, 24, 32])
+
+    def test_allowable_pilot_signals_duplicates(self):
+        self.assertEqual(self.evse3.allowable_pilot_signals,
+            [0, 8, 16, 24, 32])
+
+    def test_allowable_pilot_signals_no_zero(self):
+        self.assertEqual(self.evse4.allowable_pilot_signals,
             [0, 8, 16, 24, 32])
 
     def test_set_pilot_has_ev_invalid_rate(self):


### PR DESCRIPTION
Standardizes `allowable_rates` attribute in `FiniteRatesEVSE` objects. The`allowable_rates` attribute is now a list of rates, sorted in increasing order, with each rate occurring once and 0 included. User input to `__init__` is processed accordingly. Appropriate tests have been added.