### PR TITLE
Settable tolerance for is_feasible

### DIFF
--- a/acnportal/acnsim/interface.py
+++ b/acnportal/acnsim/interface.py
@@ -161,10 +161,13 @@ class Interface:
         network = self._simulator.network
         return Constraint(network.constraint_matrix, network.magnitudes, network.constraint_index, network.station_ids)
 
-    def is_feasible(self, load_currents, linear=False, violation_tolerance=None):
+    def is_feasible(self, load_currents, linear=False, violation_tolerance=None, relative_tolerance=None):
         """ Return if a set of current magnitudes for each load are feasible.
 
         Wraps Network's is_feasible method.
+
+        For a given constraint, the larger of the violation_tolerance
+        and relative_tolerance is used to evaluate feasibility.
 
         Args:
             load_currents (Dict[str, List[number]]): Dictionary mapping load_ids to schedules of charging rates.
@@ -173,6 +176,10 @@ class Interface:
             violation_tolerance (float): Absolute amount by which
                 schedule may violate network constraints. Default
                 None, in which case the network's violation_tolerance
+                attribute is used.
+            relative_tolerance (float): Relative amount by which
+                schedule may violate network constraints. Default
+                None, in which case the network's relative_tolerance
                 attribute is used.
 
         Returns:
@@ -190,7 +197,7 @@ class Interface:
         # Convert input schedule into its matrix representation
         schedule_matrix = np.array(
             [load_currents[evse_id] if evse_id in load_currents else [0] * schedule_length for evse_id in self._simulator.network.station_ids])
-        return self._simulator.network.is_feasible(schedule_matrix, linear, violation_tolerance)
+        return self._simulator.network.is_feasible(schedule_matrix, linear, violation_tolerance, relative_tolerance)
 
     def get_prices(self, length, start=None):
         """ Get a vector of prices beginning at time start and continuing for length periods. ($/kWh)

--- a/acnportal/acnsim/interface.py
+++ b/acnportal/acnsim/interface.py
@@ -161,7 +161,7 @@ class Interface:
         network = self._simulator.network
         return Constraint(network.constraint_matrix, network.magnitudes, network.constraint_index, network.station_ids)
 
-    def is_feasible(self, load_currents, linear=False):
+    def is_feasible(self, load_currents, linear=False, violation_tolerance=None):
         """ Return if a set of current magnitudes for each load are feasible.
 
         Wraps Network's is_feasible method.
@@ -170,6 +170,10 @@ class Interface:
             load_currents (Dict[str, List[number]]): Dictionary mapping load_ids to schedules of charging rates.
             linear (bool): If True, linearize all constraints to a more conservative but easier to compute constraint by
                 ignoring the phase angle and taking the absolute value of all load coefficients. Default False.
+            violation_tolerance (float): Absolute amount by which
+                schedule may violate network constraints. Default
+                None, in which case the network's violation_tolerance
+                attribute is used.
 
         Returns:
             bool: If load_currents is feasible at time t according to this set of constraints.
@@ -186,7 +190,7 @@ class Interface:
         # Convert input schedule into its matrix representation
         schedule_matrix = np.array(
             [load_currents[evse_id] if evse_id in load_currents else [0] * schedule_length for evse_id in self._simulator.network.station_ids])
-        return self._simulator.network.is_feasible(schedule_matrix, linear)
+        return self._simulator.network.is_feasible(schedule_matrix, linear, violation_tolerance)
 
     def get_prices(self, length, start=None):
         """ Get a vector of prices beginning at time start and continuing for length periods. ($/kWh)

--- a/acnportal/acnsim/network/charging_network.py
+++ b/acnportal/acnsim/network/charging_network.py
@@ -271,7 +271,7 @@ class ChargingNetwork:
             schedule_matrix = schedule_matrix[:, time_indices]
 
         if linear:
-            return complex(np.abs(self.constraint_matrix[constraint_indices]@schedule_matrix))
+            return np.abs(self.constraint_matrix[constraint_indices]@schedule_matrix).astype(complex)
         else:
             # build vector of phase angles on EVSE
             angle_coeffs = np.exp(1j*np.deg2rad(self._phase_angles))
@@ -310,11 +310,8 @@ class ChargingNetwork:
         aggregate_currents = self.constraint_current(schedule_matrix, linear=linear)
 
         # Ensure each aggregate current is less than its limit, returning False if not
-        if linear:
-            return np.all(self.magnitudes >= np.abs(aggregate_currents))
-        else:
-            schedule_length = schedule_matrix.shape[1]
-            return np.all(np.tile(self.magnitudes + violation_tolerance, (schedule_length, 1)).T >= np.abs(aggregate_currents))
+        schedule_length = schedule_matrix.shape[1]
+        return np.all(np.tile(self.magnitudes + violation_tolerance, (schedule_length, 1)).T >= np.abs(aggregate_currents))
 
 
 class StationOccupiedError(Exception):

--- a/acnportal/acnsim/network/charging_network.py
+++ b/acnportal/acnsim/network/charging_network.py
@@ -8,9 +8,13 @@ class ChargingNetwork:
     """
     The ChargingNetwork class describes the infrastructure of the charging network with
     information about the types of the charging station_schedule.
+
+    Args:
+        violation_tolerance (float): Absolute amount by which an input
+            charging schedule may violate network constrants (A).
     """
 
-    def __init__(self):
+    def __init__(self, violation_tolerance=1e-5):
         self._EVSEs = OrderedDict()
         # Matrix of constraints
         self.constraint_matrix = None
@@ -20,6 +24,7 @@ class ChargingNetwork:
         self.constraint_index = []
         self._voltages = np.array([])
         self._phase_angles = np.array([])
+        self.violation_tolerance = violation_tolerance
         pass
 
     @property

--- a/acnportal/acnsim/network/charging_network.py
+++ b/acnportal/acnsim/network/charging_network.py
@@ -271,7 +271,7 @@ class ChargingNetwork:
             schedule_matrix = schedule_matrix[:, time_indices]
 
         if linear:
-            return np.abs(self.constraint_matrix[constraint_indices]@schedule_matrix).astype(complex)
+            return np.abs(self.constraint_matrix[constraint_indices]@schedule_matrix).astype('complex')
         else:
             # build vector of phase angles on EVSE
             angle_coeffs = np.exp(1j*np.deg2rad(self._phase_angles))

--- a/acnportal/acnsim/network/tests/test_network.py
+++ b/acnportal/acnsim/network/tests/test_network.py
@@ -15,7 +15,8 @@ import numpy as np
 class TestChargingNetwork(TestCase):
     def setUp(self):
         self.network = ChargingNetwork()
-        self.network_with_tolerance = ChargingNetwork(violation_tolerance=1e-3)
+        self.network_with_tolerance = ChargingNetwork(violation_tolerance=1e-3,
+                                                      relative_tolerance=1e-5)
 
     def _test_init_empty(self, network):
         self.assertEqual(network._EVSEs, OrderedDict())
@@ -28,10 +29,12 @@ class TestChargingNetwork(TestCase):
     def test_init_default_tolerance(self):
         self._test_init_empty(self.network)
         self.assertEqual(self.network.violation_tolerance, 1e-5)
+        self.assertEqual(self.network.relative_tolerance, 1e-7)
 
     def test_init_default_tolerance_set(self):
         self._test_init_empty(self.network_with_tolerance)
         self.assertEqual(self.network_with_tolerance.violation_tolerance, 1e-3)
+        self.assertEqual(self.network_with_tolerance.relative_tolerance, 1e-5)
 
     def test_register_evse(self):
         evse1 = EVSE('PS-001')
@@ -231,6 +234,14 @@ class TestChargingNetworkConstraints(TestCase):
     def test_is_feasible_barely_bad_loads_set(self):
         bad_loads = np.array([[160, 200.0045], [0, 0], [0, 0], [20.0015, 0], [0, 0]])
         self.assertFalse(self.network.is_feasible(bad_loads, violation_tolerance=1e-3))
+
+    def test_is_feasible_barely_good_loads_rel_set(self):
+        good_loads = np.array([[160, 200.15], [0, 0], [0, 0], [20.015, 0], [0, 0]])
+        self.assertTrue(self.network.is_feasible(good_loads, relative_tolerance=1e-3))
+
+    def test_is_feasible_barely_bad_loads_rel_set(self):
+        bad_loads = np.array([[160, 200.21], [0, 0], [0, 0], [20.021, 0], [0, 0]])
+        self.assertFalse(self.network.is_feasible(bad_loads, relative_tolerance=1e-3))
 
     def test_is_feasible_barely_good_loads_set_linear(self):
         good_loads = np.array([[160, 200.0035], [0, 0], [0, 0], [20.0015, 0], [0, 0]])

--- a/acnportal/acnsim/network/tests/test_network.py
+++ b/acnportal/acnsim/network/tests/test_network.py
@@ -217,28 +217,28 @@ class TestChargingNetworkConstraints(TestCase):
         self.assertFalse(self.network.is_feasible(bad_loads))
 
     def test_is_feasible_barely_good_loads(self):
-        good_loads = np.array([[120, 200.000035], [0, 0], [0, 0], [20.000015, 0], [0, 0]])
+        good_loads = np.array([[160, 200.000035], [0, 0], [0, 0], [20.000015, 0], [0, 0]])
         self.assertTrue(self.network.is_feasible(good_loads))
 
     def test_is_feasible_barely_bad_loads(self):
-        good_loads = np.array([[120, 200.000045], [0, 0], [0, 0], [20.000015, 0], [0, 0]])
-        self.assertFalse(self.network.is_feasible(good_loads))
+        bad_loads = np.array([[160, 200.000045], [0, 0], [0, 0], [20.000015, 0], [0, 0]])
+        self.assertFalse(self.network.is_feasible(bad_loads))
 
     def test_is_feasible_barely_good_loads_set(self):
-        good_loads = np.array([[120, 200.0035], [0, 0], [0, 0], [20.0015, 0], [0, 0]])
+        good_loads = np.array([[160, 200.0035], [0, 0], [0, 0], [20.0015, 0], [0, 0]])
         self.assertTrue(self.network.is_feasible(good_loads, violation_tolerance=1e-3))
 
     def test_is_feasible_barely_bad_loads_set(self):
-        good_loads = np.array([[120, 200.0045], [0, 0], [0, 0], [20.0015, 0], [0, 0]])
-        self.assertFalse(self.network.is_feasible(good_loads, violation_tolerance=1e-3))
+        bad_loads = np.array([[160, 200.0045], [0, 0], [0, 0], [20.0015, 0], [0, 0]])
+        self.assertFalse(self.network.is_feasible(bad_loads, violation_tolerance=1e-3))
 
     def test_is_feasible_barely_good_loads_set_linear(self):
-        good_loads = np.array([[120, 200.0035], [0, 0], [0, 0], [20.0015, 0], [0, 0]])
+        good_loads = np.array([[160, 200.0035], [0, 0], [0, 0], [20.0015, 0], [0, 0]])
         self.assertTrue(self.network.is_feasible(good_loads, violation_tolerance=1e-3, linear=True))
 
     def test_is_feasible_barely_bad_loads_set_linear(self):
-        good_loads = np.array([[120, 200.0045], [0, 0], [0, 0], [20.0015, 0], [0, 0]])
-        self.assertFalse(self.network.is_feasible(good_loads, violation_tolerance=1e-3, linear=True))
+        bad_loads = np.array([[160, 200.0045], [0, 0], [0, 0], [20.0015, 0], [0, 0]])
+        self.assertFalse(self.network.is_feasible(bad_loads, violation_tolerance=1e-3, linear=True))
 
     def test_constraint_current(self):
         loads = np.array([[0, 0], [150, 120], [100, 40], [150, 120], [60, 9]])

--- a/acnportal/acnsim/network/tests/test_network.py
+++ b/acnportal/acnsim/network/tests/test_network.py
@@ -232,6 +232,14 @@ class TestChargingNetworkConstraints(TestCase):
         good_loads = np.array([[120, 200.0045], [0, 0], [0, 0], [20.0015, 0], [0, 0]])
         self.assertFalse(self.network.is_feasible(good_loads, violation_tolerance=1e-3))
 
+    def test_is_feasible_barely_good_loads_set_linear(self):
+        good_loads = np.array([[120, 200.0035], [0, 0], [0, 0], [20.0015, 0], [0, 0]])
+        self.assertTrue(self.network.is_feasible(good_loads, violation_tolerance=1e-3, linear=True))
+
+    def test_is_feasible_barely_bad_loads_set_linear(self):
+        good_loads = np.array([[120, 200.0045], [0, 0], [0, 0], [20.0015, 0], [0, 0]])
+        self.assertFalse(self.network.is_feasible(good_loads, violation_tolerance=1e-3, linear=True))
+
     def test_constraint_current(self):
         loads = np.array([[0, 0], [150, 120], [100, 40], [150, 120], [60, 9]])
         np.testing.assert_allclose(self.network.constraint_current(loads),

--- a/acnportal/acnsim/network/tests/test_network.py
+++ b/acnportal/acnsim/network/tests/test_network.py
@@ -15,14 +15,23 @@ import numpy as np
 class TestChargingNetwork(TestCase):
     def setUp(self):
         self.network = ChargingNetwork()
+        self.network_with_tolerance = ChargingNetwork(violation_tolerance=1e-3)
 
-    def test_init_empty(self):
-        self.assertEqual(self.network._EVSEs, OrderedDict())
-        self.assertEqual(self.network.constraint_matrix, None)
-        self.assertEqual(self.network.constraint_index, [])
-        np.testing.assert_equal(self.network.magnitudes, np.array([]))
-        np.testing.assert_equal(self.network._voltages, np.array([]))
-        np.testing.assert_equal(self.network._phase_angles, np.array([]))
+    def _test_init_empty(self, network):
+        self.assertEqual(network._EVSEs, OrderedDict())
+        self.assertEqual(network.constraint_matrix, None)
+        self.assertEqual(network.constraint_index, [])
+        np.testing.assert_equal(network.magnitudes, np.array([]))
+        np.testing.assert_equal(network._voltages, np.array([]))
+        np.testing.assert_equal(network._phase_angles, np.array([]))
+
+    def test_init_default_tolerance(self):
+        self._test_init_empty(self.network)
+        self.assertEqual(self.network.violation_tolerance, 1e-5)
+
+    def test_init_default_tolerance(self):
+        self._test_init_empty(self.network_with_tolerance)
+        self.assertEqual(self.network_with_tolerance.violation_tolerance, 1e-3)
 
     def test_register_evse(self):
         evse1 = EVSE('PS-001')

--- a/acnportal/acnsim/network/tests/test_network.py
+++ b/acnportal/acnsim/network/tests/test_network.py
@@ -216,6 +216,22 @@ class TestChargingNetworkConstraints(TestCase):
         bad_loads = np.array([[0, 0], [150, 800], [100, 0], [150, 20], [60, 9]])
         self.assertFalse(self.network.is_feasible(bad_loads))
 
+    def test_is_feasible_barely_good_loads(self):
+        good_loads = np.array([[120, 200.000035], [0, 0], [0, 0], [20.000015, 0], [0, 0]])
+        self.assertTrue(self.network.is_feasible(good_loads))
+
+    def test_is_feasible_barely_bad_loads(self):
+        good_loads = np.array([[120, 200.000045], [0, 0], [0, 0], [20.000015, 0], [0, 0]])
+        self.assertFalse(self.network.is_feasible(good_loads))
+
+    def test_is_feasible_barely_good_loads_set(self):
+        good_loads = np.array([[120, 200.0035], [0, 0], [0, 0], [20.0015, 0], [0, 0]])
+        self.assertTrue(self.network.is_feasible(good_loads, violation_tolerance=1e-3))
+
+    def test_is_feasible_barely_bad_loads_set(self):
+        good_loads = np.array([[120, 200.0045], [0, 0], [0, 0], [20.0015, 0], [0, 0]])
+        self.assertFalse(self.network.is_feasible(good_loads, violation_tolerance=1e-3))
+
     def test_constraint_current(self):
         loads = np.array([[0, 0], [150, 120], [100, 40], [150, 120], [60, 9]])
         np.testing.assert_allclose(self.network.constraint_current(loads),

--- a/acnportal/acnsim/network/tests/test_network.py
+++ b/acnportal/acnsim/network/tests/test_network.py
@@ -29,7 +29,7 @@ class TestChargingNetwork(TestCase):
         self._test_init_empty(self.network)
         self.assertEqual(self.network.violation_tolerance, 1e-5)
 
-    def test_init_default_tolerance(self):
+    def test_init_default_tolerance_set(self):
         self._test_init_empty(self.network_with_tolerance)
         self.assertEqual(self.network_with_tolerance.violation_tolerance, 1e-3)
 

--- a/acnportal/acnsim/simulator.py
+++ b/acnportal/acnsim/simulator.py
@@ -158,7 +158,17 @@ class Simulator:
 
         schedule_matrix = np.array([new_schedule[evse_id] if evse_id in new_schedule else [0] * schedule_length for evse_id in self.network.station_ids])
         if not self.network.is_feasible(schedule_matrix):
-            warnings.warn("Invalid schedule provided at iteration {0}".format(self._iteration), UserWarning)
+            aggregate_currents = self.network.constraint_current(schedule_matrix)
+            diff_vec = np.abs(aggregate_currents) - np.tile(self.network.magnitudes + self.network.violation_tolerance, (schedule_length, 1)).T
+            max_idx = np.unravel_index(np.argmax(diff_vec), diff_vec.shape)
+            max_diff = diff_vec[max_idx]
+            max_timeidx = max_idx[1]
+            max_constraint = self.network.constraint_index[max_idx[0]]
+            warnings.warn(
+                f"Invalid schedule provided at iteration {self._iteration}. "
+                f"Max violation is {max_diff} A on {max_constraint} "
+                f"at time index {max_timeidx}.",
+                UserWarning)
         if self._iteration + schedule_length <= self.pilot_signals.shape[1]:
             self.pilot_signals[:, self._iteration:(self._iteration + schedule_length)] = schedule_matrix
         else:

--- a/acnportal/acnsim/tests/test_interface.py
+++ b/acnportal/acnsim/tests/test_interface.py
@@ -51,7 +51,7 @@ class TestInterface(TestCase):
     def test_is_feasible(self):
         # Mock network's is_feasible function to check its call signature later
         self.network.is_feasible = create_autospec(self.network.is_feasible)
-        _ = self.interface.is_feasible({'PS-001' : [1, 2], 'PS-002' : [4, 5]})
+        self.interface.is_feasible({'PS-001' : [1, 2], 'PS-002' : [4, 5]})
         network_is_feasible_args = self.network.is_feasible.call_args
         # Check that the call to the network's is_feasible method has the correct arguments
         np.testing.assert_allclose(network_is_feasible_args[0][0], np.array([[1, 2], [0, 0], [4, 5]]))
@@ -63,7 +63,7 @@ class TestInterface(TestCase):
     def test_is_feasible_with_options(self):
         # Mock network's is_feasible function to check its call signature later
         self.network.is_feasible = create_autospec(self.network.is_feasible)
-        _ = self.interface.is_feasible({'PS-001' : [1, 2], 'PS-002' : [4, 5]}, linear=True, violation_tolerance=1e-3)
+        self.interface.is_feasible({'PS-001' : [1, 2], 'PS-002' : [4, 5]}, linear=True, violation_tolerance=1e-3)
         network_is_feasible_args = self.network.is_feasible.call_args
         # Check that the call to the network's is_feasible method has the correct arguments
         np.testing.assert_allclose(network_is_feasible_args[0][0], np.array([[1, 2], [0, 0], [4, 5]]))

--- a/acnportal/acnsim/tests/test_interface.py
+++ b/acnportal/acnsim/tests/test_interface.py
@@ -59,13 +59,15 @@ class TestInterface(TestCase):
         self.assertEqual(network_is_feasible_args[0][1], False)
         # Network's is_feasible method has its third argument (violation_tolerance) defaulting to None. Check this is the case.
         self.assertIsNone(network_is_feasible_args[0][2])
+        self.assertIsNone(network_is_feasible_args[0][3])
 
     def test_is_feasible_with_options(self):
         # Mock network's is_feasible function to check its call signature later
         self.network.is_feasible = create_autospec(self.network.is_feasible)
-        self.interface.is_feasible({'PS-001' : [1, 2], 'PS-002' : [4, 5]}, linear=True, violation_tolerance=1e-3)
+        self.interface.is_feasible({'PS-001' : [1, 2], 'PS-002' : [4, 5]}, linear=True, violation_tolerance=1e-3, relative_tolerance=1e-5)
         network_is_feasible_args = self.network.is_feasible.call_args
         # Check that the call to the network's is_feasible method has the correct arguments
         np.testing.assert_allclose(network_is_feasible_args[0][0], np.array([[1, 2], [0, 0], [4, 5]]))
         self.assertEqual(network_is_feasible_args[0][1], True)
         self.assertEqual(network_is_feasible_args[0][2], 1e-3)
+        self.assertEqual(network_is_feasible_args[0][3], 1e-5)

--- a/acnportal/acnsim/tests/test_interface.py
+++ b/acnportal/acnsim/tests/test_interface.py
@@ -57,3 +57,15 @@ class TestInterface(TestCase):
         np.testing.assert_allclose(network_is_feasible_args[0][0], np.array([[1, 2], [0, 0], [4, 5]]))
         # Network's is_feasible method has its second argument (linear) defaulting to False. Check this is the case.
         self.assertEqual(network_is_feasible_args[0][1], False)
+        # Network's is_feasible method has its third argument (violation_tolerance) defaulting to None. Check this is the case.
+        self.assertIsNone(network_is_feasible_args[0][2])
+
+    def test_is_feasible_with_options(self):
+        # Mock network's is_feasible function to check its call signature later
+        self.network.is_feasible = create_autospec(self.network.is_feasible)
+        _ = self.interface.is_feasible({'PS-001' : [1, 2], 'PS-002' : [4, 5]}, linear=True, violation_tolerance=1e-3)
+        network_is_feasible_args = self.network.is_feasible.call_args
+        # Check that the call to the network's is_feasible method has the correct arguments
+        np.testing.assert_allclose(network_is_feasible_args[0][0], np.array([[1, 2], [0, 0], [4, 5]]))
+        self.assertEqual(network_is_feasible_args[0][1], True)
+        self.assertEqual(network_is_feasible_args[0][2], 1e-3)

--- a/acnportal/acnsim/tests/test_simulator.py
+++ b/acnportal/acnsim/tests/test_simulator.py
@@ -93,7 +93,7 @@ class TestSimulatorWarnings(TestCase):
                         'PS-002': [0,   0, 26,  0 ],
                         'PS-006': [0,   0, 0,   40]}
         with self.assertWarnsRegex(
-            UserWarning,
-            r'Invalid schedule provided at iteration 0. '
-            r'Max violation is 2.9999\d+? A on _const_1 at time index 2.'):
+                UserWarning,
+                r'Invalid schedule provided at iteration 0. '
+                r'Max violation is 2.9999\d+? A on _const_1 at time index 2.'):
             simulator._update_schedules(bad_schedule)

--- a/acnportal/acnsim/tests/test_simulator.py
+++ b/acnportal/acnsim/tests/test_simulator.py
@@ -5,7 +5,7 @@ import numpy as np
 import pandas as pd
 
 from acnportal.acnsim import Simulator
-from acnportal.acnsim.network import ChargingNetwork
+from acnportal.acnsim.network import ChargingNetwork, Current
 from acnportal.algorithms import BaseAlgorithm
 from acnportal.acnsim.events import EventQueue, Event
 from datetime import datetime
@@ -66,3 +66,34 @@ class TestSimulator(TestCase):
         pd.testing.assert_frame_equal(outframe,
             pd.DataFrame(np.array([[1.1, 3.1, 5.1], [2.1, 4.1, 6.1]]),
                 columns=['PS-001', 'PS-002', 'PS-003']))
+
+class TestSimulatorWarnings(TestCase):
+    def test_update_schedules_infeasible_schedule(self):
+        network = ChargingNetwork()
+        network.register_evse(EVSE('PS-001'), 240, 0)
+        network.register_evse(EVSE('PS-004'), 240, 0)
+        network.register_evse(EVSE('PS-003'), 240, 0)
+        network.register_evse(EVSE('PS-002'), 240, 0)
+        network.register_evse(EVSE('PS-006'), 240, 0)
+        curr_dict1 = {'PS-001' : 0.25, 'PS-002' : 0.50, 'PS-003' : -0.25}
+        current1 = Current(curr_dict1)
+        curr_dict2 = {'PS-006' : 0.30, 'PS-004' : -0.60, 'PS-002' : 0.50}
+        current2 = Current(curr_dict2)
+        network.add_constraint(current1, 50, name='first_constraint')
+        network.add_constraint(current2, 10)
+        start = Mock(datetime)
+        scheduler = create_autospec(BaseAlgorithm)
+        scheduler.max_recompute = None
+        events = EventQueue(events=[Event(1), Event(2)])
+        simulator = Simulator(network, scheduler, events, start)
+
+        bad_schedule = {'PS-001': [200, 0, 160, 0 ],
+                        'PS-004': [0,   0, 0,   0 ],
+                        'PS-003': [0,   0, 0,   0 ],
+                        'PS-002': [0,   0, 26,  0 ],
+                        'PS-006': [0,   0, 0,   40]}
+        with self.assertWarnsRegex(
+            UserWarning,
+            r'Invalid schedule provided at iteration 0. '
+            r'Max violation is 2.9999\d+? A on _const_1 at time index 2.'):
+            simulator._update_schedules(bad_schedule)


### PR DESCRIPTION
This pull request adds functionality to set tolerance for `is_feasible` at both the network initialization and interface levels. Also, the warning raised upon submission of an invalid schedule is more descriptive, now containing the maximum violation, the time index at which this violation occurred, and the constraint that this violation violated.