### PR TITLE
Add battery models which were only in algorithms_deadband.

### DIFF
--- a/acnportal/acnsim/models/battery.py
+++ b/acnportal/acnsim/models/battery.py
@@ -1,4 +1,5 @@
 import numpy as np
+import warnings
 from ..base import BaseSimObj
 
 IDEAL = 'Ideal'
@@ -131,10 +132,108 @@ class Linear2StageBattery(Battery):
     def __init__(self, capacity, init_charge, max_power, noise_level=0, transition_soc=0.8):
         super().__init__(capacity, init_charge, max_power)
         self._noise_level = noise_level
+        if transition_soc < 0:
+            raise ValueError(
+                f"transition_soc must be nonnegative. Got {transition_soc}.")
+        elif transition_soc >= 1:
+            raise ValueError(
+                f"transition_soc must be less than 1. Got {transition_soc}.")
         self._transition_soc = transition_soc
 
     def charge(self, pilot, voltage, period):
-        """ Method to "charge" the battery based on a two-stage linear battery model.
+        """ Method to "charge" the battery based on a two-stage linear
+        battery model.
+
+        All calculations are done in terms fo battery state of charge
+        (SoC). Results are converted back to power units at the end.
+
+        Args:
+            pilot (float): Pilot signal passed to the battery. [A]
+            voltage (float): AC voltage provided to the battery
+                charger. [V]
+            period (float): Length of the charging period. [minutes]
+
+        Returns:
+            float: average charging rate of the battery over this single
+                period.
+
+        """
+        if voltage <= 0:
+            raise ValueError(
+                'Voltage must be greater than 0. Got {0}'.format(voltage))
+        if period <= 0:
+            raise ValueError(
+                'period must be greater than 0. Got {0}'.format(period))
+        if pilot == 0:
+            self._current_charging_power = 0
+            return 0
+        # All calculations are done in terms of battery SoC, so we
+        # convert pilot signal and max power into pilot and max rate of
+        # change of SoC.
+        pilot_dsoc = pilot * voltage / 1000 / self._capacity / (60 / period)
+        max_dsoc = self._max_power / self._capacity / (60 / period)
+
+        if pilot_dsoc > max_dsoc:
+            pilot_dsoc = max_dsoc
+
+        # The pilot SoC rate of change has a new transition SoC at˚
+        # which decreasing of max charging rate occurs.
+        pilot_transition_soc = (
+            self._transition_soc
+            + (pilot_dsoc - max_dsoc) / max_dsoc * (self._transition_soc - 1)
+        )
+
+        assert pilot_transition_soc >= self._transition_soc
+        if pilot >= 0:
+            assert pilot_transition_soc <= 1
+        else:
+            warnings.warn(f"Negative pilot signal input. Battery models"
+                          f"may not be accurate for pilot {pilot} A.")
+
+        # The charging equation depends on whether the current SoC of
+        # the battery is above or below the new transition SoC.
+        if self._soc < pilot_transition_soc:
+            # In the pre-rampdown region, the charging equation changes
+            # depending on whether charging the battery over this
+            # time period causes the battery to transition between
+            # charging regions.
+            if 1 <= (pilot_transition_soc - self._soc) / pilot_dsoc:
+                curr_soc = pilot_dsoc + self._soc
+            else:
+                curr_soc = (
+                    1
+                    + np.exp(
+                        (pilot_dsoc + self._soc - pilot_transition_soc)
+                        / (pilot_transition_soc - 1)
+                    )
+                    * (pilot_transition_soc - 1)
+                )
+        else:
+            curr_soc = (
+                1
+                + np.exp(pilot_dsoc / (pilot_transition_soc - 1))
+                * (self._soc - 1)
+            )
+
+        # Add subtractive noise to the final SoC, scaling the noise
+        # such that _noise_level is the standard deviation of the noise
+        # in the battery charging power.
+        if self._noise_level > 0:
+            raw_noise = np.random.normal(0, self._noise_level)
+            scaled_noise = raw_noise * (period / 60) / self._capacity
+            curr_soc -= abs(scaled_noise)
+
+        dsoc = curr_soc - self._soc
+        self._current_charge = curr_soc * self._capacity
+
+        # For charging power and charging rate (current), we use the
+        # the average over this time period.
+        self._current_charging_power = dsoc * self._capacity / (period / 60)
+        return self._current_charging_power * 1000 / voltage
+
+    def charge_old(self, pilot, voltage, period):
+        """ Method to "charge" the battery based on a two-stage linear
+        battery model.
 
         Args:
             pilot (float): Pilot signal passed to the battery. [A]
@@ -188,3 +287,114 @@ class Linear2StageBattery(Battery):
         )
         cls._from_dict_helper(out_obj, attribute_dict)
         return out_obj, loaded_dict
+
+
+def batt_cap_fn(requested_energy, stay_dur, voltage, period):
+    """ This function takes as input a requested energy, stay duration,
+    and measurement parameters (voltage & period) and calculates the
+    minimum capacity linear 2 stage battery such that it is
+    feasible to deliver requested_energy in stay_dur periods.
+
+    The function returns this minimum total capacity along with an
+    initial capacity, which is the maximum initial capacity the battery
+    with given total capacity may have such that it is feasible (after
+    charging at max rate) to deliver requested_energy in stay_dur
+    periods. Thus, the returned total and initial capacities maximize
+    the amount of time the battery behaves non-ideally during charging.
+
+    For more info on the capacity equations: TODO: point to paper.
+
+    Args:
+        requested_energy (float): Energy requested by this EV. If this
+            fit uses data from ACN-Data, this requested_energy is the
+            amount of energy actually delivered in real life.
+        stay_dur (float): Number of periods the EV stayed.
+        voltage (float): Voltage at which the battery is charged (V).
+        period (float): Number of minutes in a period (minutes).
+
+    """
+    def _get_init_cap(requested_energy, stay_dur, cap, voltage, period,
+                      max_rate=32, transition_soc=0.8):
+        """ Given a requested energy, stay duration, battery capacity
+        (kWh), charging voltage, period, max charging rate, and the
+        state of charge (SoC) at which non-ideal behavior begins, finds
+        the maximum initial capacity the battery may have such that
+        requested_energy is delivered in stay_dur periods, assuming
+        linear 2 stage battery behavior.
+
+        """
+        delta_soc = requested_energy / cap
+        # Maximum rate of change of SoC in per period.
+        max_dsoc = max_rate * voltage / 1000 / cap / (60 / period)
+
+        # First, assume init_soc is after the transition_soc. In this
+        # case, the max init_soc has a closed form solution.
+        init_soc = (
+            1
+            + delta_soc
+            / (np.exp(max_dsoc * stay_dur / (transition_soc - 1)) - 1)
+        )
+        if init_soc >= transition_soc:
+            return init_soc
+
+        # If that didn't work, search over all possible init_soc for the
+        # largest init_soc that still allows for delta_soc to be
+        # delivered in stay_dur periods.
+        def delta_soc_from_init_soc(init_soc):
+            if stay_dur <= (transition_soc - init_soc) / max_dsoc:
+                return max_dsoc * stay_dur
+            return (
+                1
+                + np.exp(
+                    (max_dsoc * stay_dur + init_soc - transition_soc)
+                    / (transition_soc - 1)
+                )
+                * (transition_soc - 1)
+                - init_soc
+            )
+
+        # Before that, we make sure that starting at init_soc of 0, it's
+        # possible to deliver the requested energy with this battery.
+        if delta_soc_from_init_soc(0) < delta_soc:
+            return -1
+
+        # Since max energy delivered is decreasing in init_soc, we
+        # use a binary search for a decreasing function. The default
+        # tolerance is set to 1e-9 to satisfy the tests'
+        # assertAlmostEqual default tolerance.
+        def binsearch(f, lb, ub, targ, tol=1e-9):
+            mid = (lb + ub) / 2
+            val = f(mid)
+            if abs(val - targ) < tol:
+                return mid
+            elif val - targ > 0:
+                return binsearch(f, mid, ub, targ, tol=tol)
+            else:
+                return binsearch(f, lb, mid, targ, tol=tol)
+
+        # Below an initial capacity of
+        # (transition_soc - max_dsoc * stay_dur),
+        # the same amount of charge is delivered, as charging stays
+        # entirely within the ideal region. So, we can start the binary
+        # search here.
+        init_soc = binsearch(
+            delta_soc_from_init_soc,
+            transition_soc - max_dsoc * stay_dur,
+            1, delta_soc
+        )
+
+        # If this statement is false, we could have used the closed-form
+        # solution in which charging occurs entirely in the non-ideal
+        # region.
+        assert init_soc < transition_soc
+        return init_soc * cap
+
+    # Potential capacities taken from TODO: find source.
+    potential_caps = np.array([8, 24, 40, 60, 85, 100])
+    for cap in potential_caps:
+        if requested_energy > cap:
+            continue
+        init = _get_init_cap(requested_energy, stay_dur, cap, voltage, period)
+        if init >= 0:
+            return cap, init
+    raise ValueError('No feasible battery size found.')

--- a/acnportal/acnsim/models/battery.py
+++ b/acnportal/acnsim/models/battery.py
@@ -183,10 +183,7 @@ class Linear2StageBattery(Battery):
             + (pilot_dsoc - max_dsoc) / max_dsoc * (self._transition_soc - 1)
         )
 
-        assert pilot_transition_soc >= self._transition_soc
-        if pilot >= 0:
-            assert pilot_transition_soc <= 1
-        else:
+        if pilot < 0:
             warnings.warn(f"Negative pilot signal input. Battery models"
                           f"may not be accurate for pilot {pilot} A.")
 
@@ -382,11 +379,6 @@ def batt_cap_fn(requested_energy, stay_dur, voltage, period):
             transition_soc - max_dsoc * stay_dur,
             1, delta_soc
         )
-
-        # If this statement is false, we could have used the closed-form
-        # solution in which charging occurs entirely in the non-ideal
-        # region.
-        assert init_soc < transition_soc
         return init_soc * cap
 
     # Potential capacities taken from TODO: find source.

--- a/acnportal/acnsim/models/tests/test_battery.py
+++ b/acnportal/acnsim/models/tests/test_battery.py
@@ -2,7 +2,7 @@ import unittest
 from unittest import TestCase
 from unittest.mock import patch
 
-from acnportal.acnsim.models import Battery, Linear2StageBattery
+from acnportal.acnsim.models import Battery, Linear2StageBattery, batt_cap_fn
 
 
 class TestBatteryBase(TestCase):
@@ -66,6 +66,29 @@ class TestLinear2StageBattery(TestBatteryBase):
         self.batt = Linear2StageBattery(
             100, self.init_charge, 7.68, 0)
 
+    def test_negative_transition_soc(self):
+        with self.assertRaises(ValueError):
+            self.batt = Linear2StageBattery(
+                100, 0, 7.68, 0, transition_soc=-0.1)
+
+    def test_one_transition_soc(self):
+        with self.assertRaises(ValueError):
+            self.batt = Linear2StageBattery(
+                100, 0, 7.68, 0, transition_soc=1)
+
+    def test_over_one_transitions_soc(self):
+        with self.assertRaises(ValueError):
+            self.batt = Linear2StageBattery(
+                100, 0, 7.68, 0, transition_soc=1.1)
+
+    def test_zero_pilot_charge(self):
+        self.batt = Linear2StageBattery(100, 0, 7.68, 0)
+        with patch('numpy.random.normal', return_value=1.2):
+            rate = self.batt.charge(0, 240, 5)
+        self.assertAlmostEqual(rate, 0)
+        self.assertAlmostEqual(self.batt.current_charging_power, 0)
+        self.assertAlmostEqual(self.batt._current_charge, 0)
+
     def test_valid_charge_no_noise_not_tail(self):
         self.batt = Linear2StageBattery(100, 0, 7.68, 0)
         with patch('numpy.random.normal', return_value=1.2):
@@ -93,25 +116,28 @@ class TestLinear2StageBattery(TestBatteryBase):
     def test_valid_charge_no_noise_tail(self):
         self.batt = Linear2StageBattery(100, 85, 7.68, 0)
         rate = self.batt.charge(32, 240, 5)
-        self.assertAlmostEqual(rate, 24)
-        self.assertAlmostEqual(self.batt.current_charging_power, 5.76)
-        self.assertAlmostEqual(self.batt._current_charge, 85.48)
+        self.assertAlmostEqual(rate, 23.62006344060197)
+        self.assertAlmostEqual(
+            self.batt.current_charging_power, 5.668815225744472)
+        self.assertAlmostEqual(self.batt._current_charge, 85.472401268812)
 
     def test_valid_charge_positive_noise_tail(self):
         self.batt = Linear2StageBattery(100, 85, 7.68, 1)
         with patch('numpy.random.normal', return_value=0.288):
             rate = self.batt.charge(32, 240, 5)
-        self.assertAlmostEqual(rate, 25.2)
-        self.assertAlmostEqual(self.batt.current_charging_power, 6.048)
-        self.assertAlmostEqual(self.batt._current_charge, 85.504)
+        self.assertAlmostEqual(rate, 22.42006344060197)
+        self.assertAlmostEqual(
+            self.batt.current_charging_power, 5.380815225744472)
+        self.assertAlmostEqual(self.batt._current_charge, 85.448401268812)
 
     def test_valid_charge_negative_noise_tail(self):
         self.batt = Linear2StageBattery(100, 85, 7.68, 1)
         with patch('numpy.random.normal', return_value=-0.288):
             rate = self.batt.charge(32, 240, 5)
-        self.assertAlmostEqual(rate, 22.8)
-        self.assertAlmostEqual(self.batt.current_charging_power, 5.472)
-        self.assertAlmostEqual(self.batt._current_charge, 85.456)
+        self.assertAlmostEqual(rate, 22.42006344060197)
+        self.assertAlmostEqual(
+            self.batt.current_charging_power, 5.380815225744472)
+        self.assertAlmostEqual(self.batt._current_charge, 85.448401268812)
 
     def test_charge_over_max_rate_not_tail(self):
         self.batt = Linear2StageBattery(100, 0, 7.68, 0)
@@ -123,10 +149,59 @@ class TestLinear2StageBattery(TestBatteryBase):
     def test_charge_over_capacity(self):
         self.batt = Linear2StageBattery(100, 99, 7.68, 0)
         rate = self.batt.charge(32, 240, 5)
-        self.assertAlmostEqual(rate, 1.6)
-        self.assertAlmostEqual(self.batt.current_charging_power, 0.384)
-        self.assertAlmostEqual(self.batt._current_charge, 99.032)
+        self.assertAlmostEqual(rate, 1.574670896040131)
+        self.assertAlmostEqual(
+            self.batt.current_charging_power, 0.3779210150496315)
+        self.assertAlmostEqual(self.batt._current_charge, 99.0314934179208)
 
+    def test_charge_at_threshold(self):
+        self.batt = Linear2StageBattery(100, 80, 7.68, 0)
+        rate = self.batt.charge(32, 240, 5)
+        self.assertAlmostEqual(rate, 31.49341792080207)
+        self.assertAlmostEqual(
+            self.batt.current_charging_power, 7.558420300992497)
+        self.assertAlmostEqual(self.batt._current_charge, 80.629868358416)
+    def test_charge_cross_threshold(self):
+        self.batt = Linear2StageBattery(100, 79.9, 7.68, 0)
+        rate = self.batt.charge(32, 240, 5)
+        self.assertAlmostEqual(rate, 31.63875847566334)
+        self.assertAlmostEqual(
+            self.batt.current_charging_power, 7.5933020341592)
+        self.assertAlmostEqual(self.batt._current_charge, 80.5327751695133)
+
+class TestBatteryFit(TestCase):
+    def battery_feasible(self, request, duration, voltage, period):
+        cap, init = batt_cap_fn(request, duration, voltage, period)
+        batt = Linear2StageBattery(cap, init, 32*voltage / 1000)
+        rates = []
+        for d in range(duration):
+            rates.append(batt.charge(32, voltage, period))
+        self.assertAlmostEqual((batt._current_charge - init), request)
+        self.assertAlmostEqual(request, sum(rates)*voltage/1000*(period/60))
+
+    def test_no_laxity(self):
+        voltage = 208
+        period = 5
+        max_power = 32*voltage / 1000
+        for dur in [12, 24, 32, 64]:
+            self.battery_feasible(
+                max_power*dur/(60/period), dur, voltage, period)
+
+    def test_half_laxity(self):
+        voltage = 208
+        period = 5
+        max_power = 32*voltage / 1000
+        for dur in [12, 24, 32, 64]:
+            self.battery_feasible(
+                max_power*dur/(60/period)/2, dur, voltage, period)
+
+    def test_almost_no_laxity(self):
+        voltage = 208
+        period = 5
+        max_power = 32*voltage / 1000
+        for dur in [12, 24, 32, 64]:
+            self.battery_feasible(
+                max_power*dur/(60/period)/1.001, dur, voltage, period)
 
 if __name__ == '__main__':
     unittest.main()

--- a/acnportal/acnsim/models/tests/test_battery.py
+++ b/acnportal/acnsim/models/tests/test_battery.py
@@ -64,7 +64,7 @@ class TestLinear2StageBattery(TestBatteryBase):
     def setUp(self):
         self.init_charge = 0
         self.batt = Linear2StageBattery(
-            100, self.init_charge, 7.68, 0)
+            100, self.init_charge, 7.68)
 
     def test_negative_transition_soc(self):
         with self.assertRaises(ValueError):
@@ -82,7 +82,7 @@ class TestLinear2StageBattery(TestBatteryBase):
                 100, 0, 7.68, 0, transition_soc=1.1)
 
     def test_zero_pilot_charge(self):
-        self.batt = Linear2StageBattery(100, 0, 7.68, 0)
+        self.batt = Linear2StageBattery(100, 0, 7.68)
         with patch('numpy.random.normal', return_value=1.2):
             rate = self.batt.charge(0, 240, 5)
         self.assertAlmostEqual(rate, 0)
@@ -90,7 +90,7 @@ class TestLinear2StageBattery(TestBatteryBase):
         self.assertAlmostEqual(self.batt._current_charge, 0)
 
     def test_valid_charge_no_noise_not_tail(self):
-        self.batt = Linear2StageBattery(100, 0, 7.68, 0)
+        self.batt = Linear2StageBattery(100, 0, 7.68)
         with patch('numpy.random.normal', return_value=1.2):
             rate = self.batt.charge(16, 240, 5)
         self.assertAlmostEqual(rate, 16)
@@ -114,7 +114,7 @@ class TestLinear2StageBattery(TestBatteryBase):
         self.assertAlmostEqual(self.batt._current_charge, 0.296)
 
     def test_valid_charge_no_noise_tail(self):
-        self.batt = Linear2StageBattery(100, 85, 7.68, 0)
+        self.batt = Linear2StageBattery(100, 85, 7.68)
         rate = self.batt.charge(32, 240, 5)
         self.assertAlmostEqual(rate, 23.62006344060197)
         self.assertAlmostEqual(
@@ -122,7 +122,7 @@ class TestLinear2StageBattery(TestBatteryBase):
         self.assertAlmostEqual(self.batt._current_charge, 85.472401268812)
 
     def test_valid_charge_positive_noise_tail(self):
-        self.batt = Linear2StageBattery(100, 85, 7.68, 1)
+        self.batt = Linear2StageBattery(100, 85, 7.68, noise_level=1)
         with patch('numpy.random.normal', return_value=0.288):
             rate = self.batt.charge(32, 240, 5)
         self.assertAlmostEqual(rate, 22.42006344060197)
@@ -140,14 +140,14 @@ class TestLinear2StageBattery(TestBatteryBase):
         self.assertAlmostEqual(self.batt._current_charge, 85.448401268812)
 
     def test_charge_over_max_rate_not_tail(self):
-        self.batt = Linear2StageBattery(100, 0, 7.68, 0)
+        self.batt = Linear2StageBattery(100, 0, 7.68)
         rate = self.batt.charge(40, 240, 5)
         self.assertAlmostEqual(rate, 32)
         self.assertAlmostEqual(self.batt.current_charging_power, 7.68)
         self.assertAlmostEqual(self.batt._current_charge, 0.64)
 
     def test_charge_over_capacity(self):
-        self.batt = Linear2StageBattery(100, 99, 7.68, 0)
+        self.batt = Linear2StageBattery(100, 99, 7.68)
         rate = self.batt.charge(32, 240, 5)
         self.assertAlmostEqual(rate, 1.574670896040131)
         self.assertAlmostEqual(
@@ -155,19 +155,21 @@ class TestLinear2StageBattery(TestBatteryBase):
         self.assertAlmostEqual(self.batt._current_charge, 99.0314934179208)
 
     def test_charge_at_threshold(self):
-        self.batt = Linear2StageBattery(100, 80, 7.68, 0)
+        self.batt = Linear2StageBattery(100, 80, 7.68)
         rate = self.batt.charge(32, 240, 5)
         self.assertAlmostEqual(rate, 31.49341792080207)
         self.assertAlmostEqual(
             self.batt.current_charging_power, 7.558420300992497)
         self.assertAlmostEqual(self.batt._current_charge, 80.629868358416)
+
     def test_charge_cross_threshold(self):
-        self.batt = Linear2StageBattery(100, 79.9, 7.68, 0)
+        self.batt = Linear2StageBattery(100, 79.9, 7.68)
         rate = self.batt.charge(32, 240, 5)
         self.assertAlmostEqual(rate, 31.63875847566334)
         self.assertAlmostEqual(
             self.batt.current_charging_power, 7.5933020341592)
         self.assertAlmostEqual(self.batt._current_charge, 80.5327751695133)
+
 
 class TestBatteryFit(TestCase):
     def battery_feasible(self, request, duration, voltage, period):
@@ -200,6 +202,7 @@ class TestBatteryFit(TestCase):
         for dur in [12, 24, 32, 64]:
             self.battery_feasible(
                 max_power*dur/(60/period)/1.001, dur, voltage, period)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/acnportal/acnsim/models/tests/test_battery.py
+++ b/acnportal/acnsim/models/tests/test_battery.py
@@ -173,9 +173,7 @@ class TestBatteryFit(TestCase):
     def battery_feasible(self, request, duration, voltage, period):
         cap, init = batt_cap_fn(request, duration, voltage, period)
         batt = Linear2StageBattery(cap, init, 32*voltage / 1000)
-        rates = []
-        for d in range(duration):
-            rates.append(batt.charge(32, voltage, period))
+        rates = [batt.charge(32, voltage, period) for _ in range(duration)]
         self.assertAlmostEqual((batt._current_charge - init), request)
         self.assertAlmostEqual(request, sum(rates)*voltage/1000*(period/60))
 

--- a/acnportal/acnsim/models/tests/test_battery.py
+++ b/acnportal/acnsim/models/tests/test_battery.py
@@ -108,7 +108,7 @@ class TestLinear2StageBatteryStepwiseCharge(TestBatteryBase):
         self.assertAlmostEqual(self.batt._current_charge, 0.32)
 
     def test_valid_charge_positive_noise_not_tail(self):
-        self.batt = Linear2StageBattery(100, 0, 7.68, 1,
+        self.batt = Linear2StageBattery(100, 0, 7.68, noise_level=1,
                                         charge_calculation='stepwise')
         with patch('numpy.random.normal', return_value=0.288):
             rate = self.batt.charge(16, 240, 5)
@@ -117,7 +117,7 @@ class TestLinear2StageBatteryStepwiseCharge(TestBatteryBase):
         self.assertAlmostEqual(self.batt._current_charge, 0.296)
 
     def test_valid_charge_negative_noise_not_tail(self):
-        self.batt = Linear2StageBattery(100, 0, 7.68, 1,
+        self.batt = Linear2StageBattery(100, 0, 7.68, noise_level=1,
                                         charge_calculation='stepwise')
         with patch('numpy.random.normal', return_value=-0.288):
             rate = self.batt.charge(16, 240, 5)
@@ -134,7 +134,7 @@ class TestLinear2StageBatteryStepwiseCharge(TestBatteryBase):
         self.assertAlmostEqual(self.batt._current_charge, 85.48)
 
     def test_valid_charge_positive_noise_tail(self):
-        self.batt = Linear2StageBattery(100, 85, 7.68, 1,
+        self.batt = Linear2StageBattery(100, 85, 7.68, noise_level=1,
                                         charge_calculation='stepwise')
         with patch('numpy.random.normal', return_value=0.288):
             rate = self.batt.charge(32, 240, 5)
@@ -143,7 +143,7 @@ class TestLinear2StageBatteryStepwiseCharge(TestBatteryBase):
         self.assertAlmostEqual(self.batt._current_charge, 85.504)
 
     def test_valid_charge_negative_noise_tail(self):
-        self.batt = Linear2StageBattery(100, 85, 7.68, 1,
+        self.batt = Linear2StageBattery(100, 85, 7.68, noise_level=1,
                                         charge_calculation='stepwise')
         with patch('numpy.random.normal', return_value=-0.288):
             rate = self.batt.charge(32, 240, 5)
@@ -192,7 +192,7 @@ class TestLinear2StageBattery(TestLinear2StageBatteryStepwiseCharge):
         self.assertAlmostEqual(self.batt._current_charge, 85.448401268812)
 
     def test_valid_charge_negative_noise_tail(self):
-        self.batt = Linear2StageBattery(100, 85, 7.68, 1)
+        self.batt = Linear2StageBattery(100, 85, 7.68, noise_level=1)
         with patch('numpy.random.normal', return_value=-0.288):
             rate = self.batt.charge(32, 240, 5)
         self.assertAlmostEqual(rate, 22.42006344060197)

--- a/acnportal/signals/loads/load.py
+++ b/acnportal/signals/loads/load.py
@@ -1,6 +1,0 @@
-# coding=utf-8
-"""
-This module represents electrical loads and generation for use
-as input signals to ACN-Sim.
-"""
-

--- a/acnportal/signals/loads/load.py
+++ b/acnportal/signals/loads/load.py
@@ -1,0 +1,6 @@
+# coding=utf-8
+"""
+This module represents electrical loads and generation for use
+as input signals to ACN-Sim.
+"""
+


### PR DESCRIPTION
Added your battery_fitting code which I couldn't find outside of the algorithms_deadband branch which I am trying to split into smaller PRs. 