### PR TITLE
Update test_current.py for Pandas 1.1.0

### DIFF
--- a/acnportal/acnsim/network/current.py
+++ b/acnportal/acnsim/network/current.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Union, Dict, SupportsFloat, List
+from typing import Union, Dict, SupportsFloat, List, Optional
 
 import pandas as pd
 
@@ -20,36 +20,24 @@ class Current(pd.Series):
 
     def __init__(
         self,
-        loads: Union[Dict[str, SupportsFloat], str, List[str], pd.Series] = None,
-        **kwargs
+        loads: Optional[
+            Union[Dict[str, SupportsFloat], str, List[str], pd.Series]
+        ] = None,
     ):
-        # This subclass doesn't use the data keyword argument, so if the user
-        # provides it, a warning is raised.
-        if "data" in kwargs and kwargs["data"] is not None:
-            warnings.warn(
-                "Current class does not use the data keyword of Series constructor. "
-                "Use the loads keyword instead."
-            )
-
-        # Remove "data" keyword for passing up to constructor.
-        if "data" in kwargs:
-            del kwargs["data"]
 
         # Backwards compatibility with previous Current specification methods
         if isinstance(loads, dict):
-            super().__init__(loads, **kwargs)
+            super().__init__(loads)
         elif isinstance(loads, str):
-            super().__init__({loads: 1}, **kwargs)
+            super().__init__({loads: 1})
         elif loads is not None and all(isinstance(load, str) for load in loads):
-            super().__init__({load_id: 1 for load_id in loads}, **kwargs)
+            super().__init__({load_id: 1 for load_id in loads})
         elif isinstance(loads, pd.Series):
-            super().__init__(loads, **kwargs)
+            super().__init__(loads)
         elif loads is None:
             # The object type is specified explicitly here to address a
             # warning in pandas 1.x.
-            if "dtype" not in kwargs:
-                kwargs["dtype"] = "float64"
-            super().__init__(**kwargs)
+            super().__init__(dtype="float64")
         else:
             raise TypeError(
                 "Variable loads should be of type dict, str, pd.Series, or Lst[str]."

--- a/acnportal/acnsim/network/current.py
+++ b/acnportal/acnsim/network/current.py
@@ -1,4 +1,3 @@
-import warnings
 from typing import Union, Dict, SupportsFloat, List, Optional
 
 import pandas as pd

--- a/acnportal/acnsim/network/tests/test_current.py
+++ b/acnportal/acnsim/network/tests/test_current.py
@@ -42,14 +42,6 @@ class TestCurrent(TestCase):
             Current(pd.Series([1, 1, 1], index=["PS-001", "PS-002", "PS-003"])),
         )
 
-    def test_init_data_warning(self):
-        with self.assertWarns(UserWarning):
-            self.current = Current(data=[1, 2, 3])
-
-    def test_supertype_kwarg_passing(self):
-        self.current = Current(name="Empty Current")
-        self.assertEqual(self.current.name, "Empty Current")
-
     def test_add_current_equal_station_ids(self):
         curr_dict1 = {"PS-001": 0.25, "PS-002": 0.50, "PS-003": -0.25}
         self.current1 = Current(curr_dict1)

--- a/acnportal/acnsim/network/tests/test_current.py
+++ b/acnportal/acnsim/network/tests/test_current.py
@@ -14,30 +14,41 @@ class TestCurrent(TestCase):
         self.current = Current(curr_dict)
         pd.testing.assert_series_equal(
             self.current,
-            pd.Series([0.25, 0.50, -0.25], index=["PS-001", "PS-002", "PS-003"]),
-            check_series_type=False
+            Current(
+                pd.Series([0.25, 0.50, -0.25], index=["PS-001", "PS-002", "PS-003"])
+            ),
         )
 
     def test_init_str_load_input(self):
         curr_str = "PS-001"
         self.current = Current(curr_str)
-        pd.testing.assert_series_equal(self.current, pd.Series([1], index=["PS-001"]),
-                                       check_series_type=False)
+        pd.testing.assert_series_equal(
+            self.current, Current(pd.Series([1], index=["PS-001"]))
+        )
 
     def test_init_none_input(self):
         self.current = Current()
         # The object type is specified explicitly here to address a
         # warning in pandas 1.x.
-        pd.testing.assert_series_equal(self.current, pd.Series(dtype="float64"),
-                                       check_series_type=False)
+        pd.testing.assert_series_equal(
+            self.current, Current(pd.Series(dtype="float64"))
+        )
 
     def test_init_str_lst_input(self):
         curr_strs = ["PS-001", "PS-002", "PS-003"]
         self.current = Current(curr_strs)
         pd.testing.assert_series_equal(
-            self.current, pd.Series([1, 1, 1], index=["PS-001", "PS-002", "PS-003"]),
-            check_series_type=False
+            self.current,
+            Current(pd.Series([1, 1, 1], index=["PS-001", "PS-002", "PS-003"])),
         )
+
+    def test_init_data_warning(self):
+        with self.assertWarns(UserWarning):
+            self.current = Current(data=[1, 2, 3])
+
+    def test_supertype_kwarg_passing(self):
+        self.current = Current(name="Empty Current")
+        self.assertEqual(self.current.name, "Empty Current")
 
     def test_add_current_equal_station_ids(self):
         curr_dict1 = {"PS-001": 0.25, "PS-002": 0.50, "PS-003": -0.25}
@@ -48,8 +59,9 @@ class TestCurrent(TestCase):
         self.assertIsInstance(self.sum_curr, Current)
         pd.testing.assert_series_equal(
             self.sum_curr,
-            pd.Series([0.55, -0.10, 0.25], index=["PS-001", "PS-002", "PS-003"]),
-            check_series_type=False
+            Current(
+                pd.Series([0.55, -0.10, 0.25], index=["PS-001", "PS-002", "PS-003"])
+            ),
         )
 
     def test_add_current_unequal_station_ids(self):
@@ -61,11 +73,12 @@ class TestCurrent(TestCase):
         self.assertIsInstance(self.sum_curr, Current)
         pd.testing.assert_series_equal(
             self.sum_curr,
-            pd.Series(
-                [0.25, 1.00, -0.25, -0.60, 0.30],
-                index=["PS-001", "PS-002", "PS-003", "PS-004", "PS-006"],
+            Current(
+                pd.Series(
+                    [0.25, 1.00, -0.25, -0.60, 0.30],
+                    index=["PS-001", "PS-002", "PS-003", "PS-004", "PS-006"],
+                )
             ),
-            check_series_type=False
         )
 
     def test_sub_current_unequal_station_ids(self):
@@ -77,11 +90,12 @@ class TestCurrent(TestCase):
         self.assertIsInstance(self.diff_curr, Current)
         pd.testing.assert_series_equal(
             self.diff_curr,
-            pd.Series(
-                [0.25, 0.00, -0.25, 0.60, -0.30],
-                index=["PS-001", "PS-002", "PS-003", "PS-004", "PS-006"],
+            Current(
+                pd.Series(
+                    [0.25, 0.00, -0.25, 0.60, -0.30],
+                    index=["PS-001", "PS-002", "PS-003", "PS-004", "PS-006"],
+                )
             ),
-            check_series_type=False
         )
 
     def test_mul_current(self):
@@ -91,6 +105,7 @@ class TestCurrent(TestCase):
         self.assertIsInstance(self.current, Current)
         pd.testing.assert_series_equal(
             self.current,
-            pd.Series([0.50, 1.00, -0.5], index=["PS-001", "PS-002", "PS-003"]),
-            check_series_type=False
+            Current(
+                pd.Series([0.50, 1.00, -0.5], index=["PS-001", "PS-002", "PS-003"])
+            ),
         )

--- a/acnportal/acnsim/network/tests/test_current.py
+++ b/acnportal/acnsim/network/tests/test_current.py
@@ -15,24 +15,28 @@ class TestCurrent(TestCase):
         pd.testing.assert_series_equal(
             self.current,
             pd.Series([0.25, 0.50, -0.25], index=["PS-001", "PS-002", "PS-003"]),
+            check_series_type=False
         )
 
     def test_init_str_load_input(self):
         curr_str = "PS-001"
         self.current = Current(curr_str)
-        pd.testing.assert_series_equal(self.current, pd.Series([1], index=["PS-001"]))
+        pd.testing.assert_series_equal(self.current, pd.Series([1], index=["PS-001"]),
+                                       check_series_type=False)
 
     def test_init_none_input(self):
         self.current = Current()
         # The object type is specified explicitly here to address a
         # warning in pandas 1.x.
-        pd.testing.assert_series_equal(self.current, pd.Series(dtype="float64"))
+        pd.testing.assert_series_equal(self.current, pd.Series(dtype="float64"),
+                                       check_series_type=False)
 
     def test_init_str_lst_input(self):
         curr_strs = ["PS-001", "PS-002", "PS-003"]
         self.current = Current(curr_strs)
         pd.testing.assert_series_equal(
-            self.current, pd.Series([1, 1, 1], index=["PS-001", "PS-002", "PS-003"])
+            self.current, pd.Series([1, 1, 1], index=["PS-001", "PS-002", "PS-003"]),
+            check_series_type=False
         )
 
     def test_add_current_equal_station_ids(self):
@@ -45,6 +49,7 @@ class TestCurrent(TestCase):
         pd.testing.assert_series_equal(
             self.sum_curr,
             pd.Series([0.55, -0.10, 0.25], index=["PS-001", "PS-002", "PS-003"]),
+            check_series_type=False
         )
 
     def test_add_current_unequal_station_ids(self):
@@ -60,6 +65,7 @@ class TestCurrent(TestCase):
                 [0.25, 1.00, -0.25, -0.60, 0.30],
                 index=["PS-001", "PS-002", "PS-003", "PS-004", "PS-006"],
             ),
+            check_series_type=False
         )
 
     def test_sub_current_unequal_station_ids(self):
@@ -75,6 +81,7 @@ class TestCurrent(TestCase):
                 [0.25, 0.00, -0.25, 0.60, -0.30],
                 index=["PS-001", "PS-002", "PS-003", "PS-004", "PS-006"],
             ),
+            check_series_type=False
         )
 
     def test_mul_current(self):
@@ -85,4 +92,5 @@ class TestCurrent(TestCase):
         pd.testing.assert_series_equal(
             self.current,
             pd.Series([0.50, 1.00, -0.5], index=["PS-001", "PS-002", "PS-003"]),
+            check_series_type=False
         )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -174,7 +174,8 @@ class TestIntegration(TestCase):
                 ),
                 np.array(
                     self.edf_algo_true_analysis_dict["primary_current_unbalance_nema"]
-                ), atol=1e-6
+                ),
+                atol=1e-6,
             )
         with self.assertWarns(RuntimeWarning):
             np.testing.assert_allclose(
@@ -183,7 +184,8 @@ class TestIntegration(TestCase):
                 ),
                 np.array(
                     self.edf_algo_true_analysis_dict["secondary_current_unbalance_nema"]
-                ), atol=1e-6
+                ),
+                atol=1e-6,
             )
 
     def test_datetimes_array_tutorial_2(self):


### PR DESCRIPTION
Tests started failing on Travis. 

We found that the newest version of Pandas (1.1.0) checks that series type (class) which fails since Current is a subclass of Series. (https://pandas.pydata.org/docs/reference/api/pandas.testing.assert_series_equal.html)

Fixed by adding check_series_type=False for all tests.