### PR TITLE
ENH: check session id before unplugging

### DIFF
--- a/acnportal/acnsim/network/charging_network.py
+++ b/acnportal/acnsim/network/charging_network.py
@@ -327,12 +327,12 @@ class ChargingNetwork(BaseSimObj):
         else:
             raise KeyError("Station {0} not found.".format(ev.station_id))
 
-    def unplug(self, station_id: str) -> None:
+    def unplug(self, station_id: str, session_id: str) -> None:
         """ Detach EV from a specific EVSE.
 
         Args:
             station_id (str): ID of the EVSE.
-
+            sesison_id (str): ID of the session to be unplugged.
         Returns:
             None
 
@@ -340,7 +340,11 @@ class ChargingNetwork(BaseSimObj):
             KeyError: Raised when the station id has not yet been registered.
         """
         if station_id in self._EVSEs:
-            self._EVSEs[station_id].unplug()
+            if session_id == self._EVSEs[station_id].ev.session_id:
+                self._EVSEs[station_id].unplug()
+            else:
+                warnings.warn(f"Tried to remove EV with session_id {session_id} which was not "
+                              f"present at station {station_id}.")
         else:
             raise KeyError("Station {0} not found.".format(station_id))
 

--- a/acnportal/acnsim/network/charging_network.py
+++ b/acnportal/acnsim/network/charging_network.py
@@ -328,7 +328,7 @@ class ChargingNetwork(BaseSimObj):
         else:
             raise KeyError("Station {0} not found.".format(ev.station_id))
 
-    def unplug(self, station_id: str, session_id: str) -> None:
+    def unplug(self, station_id: str, session_id: str = None) -> None:
         """ Detach EV from a specific EVSE.
 
         Args:
@@ -341,7 +341,20 @@ class ChargingNetwork(BaseSimObj):
             KeyError: Raised when the station id has not yet been registered.
         """
         if station_id in self._EVSEs:
-            if session_id == self._EVSEs[station_id].ev.session_id:
+            if session_id is None:
+                warnings.warn(
+                    f"Calling ChargingNetwork.unplug without a session_id argument is "
+                    f"deprecated. Please include a session_id argument as this will be "
+                    f"required in a future release. Unplugging EV at station "
+                    f"{station_id}."
+                )
+                self._EVSEs[station_id].unplug()
+            elif self._EVSEs[station_id].ev is None:
+                warnings.warn(
+                    f"Tried to remove EV with session_id {session_id} which was not "
+                    f"present at station {station_id}. Found no EV instead."
+                )
+            elif session_id == self._EVSEs[station_id].ev.session_id:
                 self._EVSEs[station_id].unplug()
             else:
                 warnings.warn(

--- a/acnportal/acnsim/network/charging_network.py
+++ b/acnportal/acnsim/network/charging_network.py
@@ -344,8 +344,10 @@ class ChargingNetwork(BaseSimObj):
             if session_id == self._EVSEs[station_id].ev.session_id:
                 self._EVSEs[station_id].unplug()
             else:
-                warnings.warn(f"Tried to remove EV with session_id {session_id} which was not "
-                              f"present at station {station_id}.")
+                warnings.warn(
+                    f"Tried to remove EV with session_id {session_id} which was not "
+                    f"present at station {station_id}."
+                )
         else:
             raise KeyError("Station {0} not found.".format(station_id))
 

--- a/acnportal/acnsim/network/charging_network.py
+++ b/acnportal/acnsim/network/charging_network.py
@@ -332,7 +332,7 @@ class ChargingNetwork(BaseSimObj):
 
         Args:
             station_id (str): ID of the EVSE.
-            sesison_id (str): ID of the session to be unplugged.
+            session_id (str): ID of the session to be unplugged.
         Returns:
             None
 

--- a/acnportal/acnsim/network/charging_network.py
+++ b/acnportal/acnsim/network/charging_network.py
@@ -346,7 +346,8 @@ class ChargingNetwork(BaseSimObj):
             else:
                 warnings.warn(
                     f"Tried to remove EV with session_id {session_id} which was not "
-                    f"present at station {station_id}."
+                    f"present at station {station_id}. Found EV with session_id "
+                    f"{self._EVSEs[station_id].ev.session_id} instead."
                 )
         else:
             raise KeyError("Station {0} not found.".format(station_id))

--- a/acnportal/acnsim/network/tests/test_network.py
+++ b/acnportal/acnsim/network/tests/test_network.py
@@ -2,7 +2,7 @@
 """ Tests for ChargingNetwork functionality. """
 from collections import OrderedDict
 from unittest import TestCase
-from unittest.mock import Mock, create_autospec
+from unittest.mock import Mock, create_autospec, patch
 
 import numpy as np
 import pandas as pd
@@ -91,16 +91,16 @@ class TestChargingNetwork(TestCase):
 
     def test_unplug_station_exists_session_id_matches(self) -> None:
         evse = self._unplug_test_setup("Session-01")
-        self.network.unplug("PS-001", "Session-01")
-        # noinspection PyUnresolvedReferences
-        evse.unplug.assert_called_once()
+        with patch.object(evse, "unplug") as unplug:
+            self.network.unplug("PS-001", "Session-01")
+        unplug.assert_called_once()
 
     def test_unplug_station_exists_session_id_mismatch(self) -> None:
         evse = self._unplug_test_setup("Session-02")
-        with self.assertWarns(UserWarning):
-            self.network.unplug("PS-001", "Session-01")
-        # noinspection PyUnresolvedReferences
-        evse.unplug.assert_not_called()
+        with patch.object(evse, "unplug") as unplug:
+            with self.assertWarns(UserWarning):
+                self.network.unplug("PS-001", "Session-01")
+        unplug.assert_not_called()
 
     def test_unplug_station_does_not_exist(self) -> None:
         with self.assertRaises(KeyError):

--- a/acnportal/acnsim/network/tests/test_network.py
+++ b/acnportal/acnsim/network/tests/test_network.py
@@ -78,25 +78,39 @@ class TestChargingNetwork(TestCase):
         with self.assertRaises(KeyError):
             self.network.plugin(ev)
 
-    def _unplug_test_setup(self, real_session_id: str) -> EVSE:
+    def test_unplug_no_ev(self) -> None:
+        evse = EVSE("PS-001")
+        self.network.register_evse(evse, 240, 0)
+        with patch.object(evse, "unplug") as unplug:
+            with self.assertWarns(UserWarning):
+                self.network.unplug("PS-001", "Session-01")
+        unplug.assert_not_called()
+
+    def _unplug_test_setup_helper(self, real_session_id: str) -> EVSE:
         evse = EVSE("PS-001")
         ev = create_autospec(EV)
         ev.station_id = "PS-001"
         ev.session_id = real_session_id
         evse.plugin(ev)
 
-        evse.unplug = Mock(evse.unplug)
         self.network.register_evse(evse, 240, 0)
         return evse
 
+    def test_unplug_no_session_id(self) -> None:
+        evse = self._unplug_test_setup_helper("Session-01")
+        with patch.object(evse, "unplug") as unplug:
+            with self.assertWarns(UserWarning):
+                self.network.unplug("PS-001")
+        unplug.assert_called_once()
+
     def test_unplug_station_exists_session_id_matches(self) -> None:
-        evse = self._unplug_test_setup("Session-01")
+        evse = self._unplug_test_setup_helper("Session-01")
         with patch.object(evse, "unplug") as unplug:
             self.network.unplug("PS-001", "Session-01")
         unplug.assert_called_once()
 
     def test_unplug_station_exists_session_id_mismatch(self) -> None:
-        evse = self._unplug_test_setup("Session-02")
+        evse = self._unplug_test_setup_helper("Session-02")
         with patch.object(evse, "unplug") as unplug:
             with self.assertWarns(UserWarning):
                 self.network.unplug("PS-001", "Session-01")

--- a/acnportal/acnsim/network/tests/test_network.py
+++ b/acnportal/acnsim/network/tests/test_network.py
@@ -100,7 +100,8 @@ class TestChargingNetwork(TestCase):
 
         evse.unplug = Mock(evse.unplug)
         self.network.register_evse(evse, 240, 0)
-        self.network.unplug("PS-001", "Session-01")
+        with self.assertWarns(UserWarning):
+            self.network.unplug("PS-001", "Session-01")
         # noinspection PyUnresolvedReferences
         evse.unplug.assert_not_called()
 

--- a/acnportal/acnsim/network/tests/test_network.py
+++ b/acnportal/acnsim/network/tests/test_network.py
@@ -78,17 +78,35 @@ class TestChargingNetwork(TestCase):
         with self.assertRaises(KeyError):
             self.network.plugin(ev)
 
-    def test_unplug_station_exists(self) -> None:
+    def test_unplug_station_exists_session_id_matches(self) -> None:
         evse = EVSE("PS-001")
+        ev = create_autospec(EV)
+        ev.station_id = "PS-001"
+        ev.session_id = "Session-01"
+        evse.plugin(ev)
+
         evse.unplug = Mock(evse.unplug)
         self.network.register_evse(evse, 240, 0)
-        self.network.unplug("PS-001")
+        self.network.unplug("PS-001", "Session-01")
         # noinspection PyUnresolvedReferences
         evse.unplug.assert_called_once()
 
+    def test_unplug_station_exists_session_id_mismatch(self) -> None:
+        evse = EVSE("PS-001")
+        ev = create_autospec(EV)
+        ev.station_id = "PS-001"
+        ev.session_id = "Session-02"
+        evse.plugin(ev)
+
+        evse.unplug = Mock(evse.unplug)
+        self.network.register_evse(evse, 240, 0)
+        self.network.unplug("PS-001", "Session-01")
+        # noinspection PyUnresolvedReferences
+        evse.unplug.assert_not_called()
+
     def test_unplug_station_does_not_exist(self) -> None:
         with self.assertRaises(KeyError):
-            self.network.unplug("PS-001")
+            self.network.unplug("PS-001", "Session-01")
 
     def test_get_ev_station_exists(self) -> None:
         evse = EVSE("PS-001")

--- a/acnportal/acnsim/simulator.py
+++ b/acnportal/acnsim/simulator.py
@@ -222,7 +222,7 @@ class Simulator(BaseSimObj):
             self._last_schedule_update = event.timestamp
         elif event.event_type == "Unplug":
             self._print("Unplug Event...")
-            self.network.unplug(event.station_id)
+            self.network.unplug(event.station_id, event.session_id)
             self._resolve = True
             self._last_schedule_update = event.timestamp
         elif event.event_type == "Recompute":

--- a/setup.py
+++ b/setup.py
@@ -13,10 +13,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     packages=setuptools.find_packages(),
     package_data={
-        "": [
-            "LICENSE.txt",
-            "THANKS.txt",
-        ],
+        "": ["LICENSE.txt", "THANKS.txt",],
         "acnportal": ["signals/tariffs/tariff_schedules/*"],
     },
     include_package_data=True,


### PR DESCRIPTION
Update `ChargingNetwork.unplug()` so that it takes in a `session_id` parameter. If the EV at the EVSE does not have a matching `session_id`, then it does not unplug it. 