### PR TITLE
Update UnplugEvent to contain an EV object instead of session_id and …

### DIFF
--- a/acnportal/acnsim/base.py
+++ b/acnportal/acnsim/base.py
@@ -652,7 +652,16 @@ class BaseSimObj:
                         loaded_attr_value = attribute_dict[attr]
                     # If the attribute was originally JSON serializable,
                     # this is correct loading.
-                    setattr(out_obj, attr, loaded_attr_value)
+                    try:
+                        setattr(out_obj, attr, loaded_attr_value)
+                    except AttributeError:
+                        # attr could be protected for out_obj. Warn if it is.
+                        warnings.warn(
+                            f"Attribute {attr} is protected for object of class "
+                            f"{out_obj.__class__}. Not setting {attr} to "
+                            f"{loaded_attr_value}. Please see {out_obj.__class__} "
+                            f"implementation for more info."
+                        )
 
         # Add this object to the dictionary of loaded objects.
         loaded_dict[obj_id] = out_obj

--- a/acnportal/acnsim/events/event.py
+++ b/acnportal/acnsim/events/event.py
@@ -102,6 +102,16 @@ class EVEvent(Event):
         super().__init__(timestamp)
         self.ev = ev
 
+    @property
+    def station_id(self) -> str:
+        """ Return the station_id for the EV associated with this Event. """
+        return self.ev.station_id
+
+    @property
+    def session_id(self) -> str:
+        """ Return the session_id for the EV associated with this Event. """
+        return self.ev.session_id
+
     def _to_dict(
         self, context_dict: Optional[Dict[str, Any]] = None
     ) -> Tuple[Dict[str, Any], Dict[str, Any]]:

--- a/acnportal/acnsim/events/event.py
+++ b/acnportal/acnsim/events/event.py
@@ -2,11 +2,13 @@
 """
 Defines several classes of Events in the simulation.
 """
-from typing import Optional, Dict, Any, Tuple
+from typing import Optional, Dict, Any, Tuple, TYPE_CHECKING
 
-from .. import EV
 from ..base import BaseSimObj
 import warnings
+
+if TYPE_CHECKING:
+    from acnportal.acnsim import EV
 
 
 class Event(BaseSimObj):
@@ -94,9 +96,9 @@ class EVEvent(Event):
         timestamp (int): See Event.
         ev (EV): The EV associated with this event.
     """
-    ev: EV
+    ev: "EV"
 
-    def __init__(self, timestamp: int, ev: EV) -> None:
+    def __init__(self, timestamp: int, ev: "EV") -> None:
         super().__init__(timestamp)
         self.ev = ev
 
@@ -138,7 +140,7 @@ class PluginEvent(EVEvent):
         ev (EV): The EV which will be plugged in.
     """
 
-    def __init__(self, timestamp: int, ev: EV) -> None:
+    def __init__(self, timestamp: int, ev: "EV") -> None:
         super().__init__(timestamp, ev)
         self.event_type = "Plugin"
         self.precedence = 10
@@ -152,7 +154,7 @@ class UnplugEvent(EVEvent):
         ev (EV): The EV which will be unplugged.
     """
 
-    def __init__(self, timestamp: int, ev: EV) -> None:
+    def __init__(self, timestamp: int, ev: "EV") -> None:
         super().__init__(timestamp, ev)
         self.event_type = "Unplug"
         self.precedence = 0

--- a/acnportal/acnsim/events/event.py
+++ b/acnportal/acnsim/events/event.py
@@ -76,8 +76,8 @@ class Event(BaseSimObj):
         return out_obj, loaded_dict
 
 
-class PluginEvent(Event):
-    """ Subclass of Event for EV plugins.
+class EVEvent(Event):
+    """ Subclass of Event for events which deal with an EV such as Plugin and Unplug events.
 
     Args:
         timestamp (int): See Event.
@@ -86,9 +86,7 @@ class PluginEvent(Event):
 
     def __init__(self, timestamp, ev):
         super().__init__(timestamp)
-        self.event_type = "Plugin"
         self.ev = ev
-        self.precedence = 10
 
     def _to_dict(
         self, context_dict: Optional[Dict[str, Any]] = None
@@ -120,47 +118,32 @@ class PluginEvent(Event):
         return out_obj, loaded_dict
 
 
-class UnplugEvent(Event):
+class PluginEvent(EVEvent):
+    """ Subclass of Event for EV plugins.
+
+    Args:
+        timestamp (int): See Event.
+        ev (EV): The EV which will be plugged in.
+    """
+
+    def __init__(self, timestamp, ev):
+        super().__init__(timestamp, ev)
+        self.event_type = "Plugin"
+        self.precedence = 10
+
+
+class UnplugEvent(EVEvent):
     """ Subclass of Event for EV unplugs.
 
     Args:
         timestamp (int): See Event.
-        station_id (str): ID of the EVSE where the EV is to be unplugged.
-        session_id (str): ID of the session which should be ended.
+        ev (EV): The EV which will be unplugged.
     """
 
-    def __init__(self, timestamp, station_id, session_id):
-        super().__init__(timestamp)
+    def __init__(self, timestamp, ev):
+        super().__init__(timestamp, ev)
         self.event_type = "Unplug"
-        self.station_id = station_id
-        self.session_id = session_id
         self.precedence = 0
-
-    def _to_dict(
-        self, context_dict: Optional[Dict[str, Any]] = None
-    ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
-        """ Implements BaseSimObj._to_dict. """
-        attribute_dict, context_dict = super()._to_dict(context_dict)
-        # Unplug-specific attributes
-        attribute_dict["station_id"] = self.station_id
-        attribute_dict["session_id"] = self.session_id
-        return attribute_dict, context_dict
-
-    @classmethod
-    def _from_dict(
-        cls,
-        attribute_dict: Dict[str, Any],
-        context_dict: Dict[str, Any],
-        loaded_dict: Optional[Dict[str, BaseSimObj]] = None,
-    ) -> Tuple[BaseSimObj, Dict[str, BaseSimObj]]:
-        """ Implements BaseSimObj._from_dict. """
-        out_obj = cls(
-            attribute_dict["timestamp"],
-            attribute_dict["station_id"],
-            attribute_dict["session_id"],
-        )
-        cls._from_dict_helper(out_obj, attribute_dict)
-        return out_obj, loaded_dict
 
 
 class RecomputeEvent(Event):

--- a/acnportal/acnsim/events/event.py
+++ b/acnportal/acnsim/events/event.py
@@ -1,5 +1,10 @@
+# coding=utf-8
+"""
+Defines several classes of Events in the simulation.
+"""
 from typing import Optional, Dict, Any, Tuple
 
+from .. import EV
 from ..base import BaseSimObj
 import warnings
 
@@ -13,17 +18,20 @@ class Event(BaseSimObj):
     Attributes:
         timestamp (int): See args.
         event_type (str): Name of the event type.
-        precedence (float): Used to order occurrence for events that happen in the same timestep. Higher precedence
-            events occur before lower precedence events.
+        precedence (float): Used to order occurrence for events that happen in the same
+            timestep. Higher precedence events occur before lower precedence events.
 
     """
+    timestamp: int
+    event_type: str
+    precedence: float
 
-    def __init__(self, timestamp):
+    def __init__(self, timestamp: int) -> None:
         self.timestamp = timestamp
         self.event_type = ""
         self.precedence = float("inf")
 
-    def __lt__(self, other):
+    def __lt__(self, other: "Event") -> bool:
         """ Return True if the precedence of self is less than that of other.
 
         Args:
@@ -35,7 +43,7 @@ class Event(BaseSimObj):
         return self.precedence < other.precedence
 
     @property
-    def type(self):
+    def type(self) -> str:
         """
         Legacy accessor for event_type. This will be removed in a future
         release.
@@ -59,7 +67,9 @@ class Event(BaseSimObj):
         return attribute_dict, context_dict
 
     @classmethod
-    def _from_dict_helper(cls, out_obj, attribute_dict):
+    def _from_dict_helper(
+        cls, out_obj: "Event", attribute_dict: Dict[str, Any]
+    ) -> None:
         out_obj.event_type = attribute_dict["event_type"]
         out_obj.precedence = attribute_dict["precedence"]
 
@@ -77,14 +87,16 @@ class Event(BaseSimObj):
 
 
 class EVEvent(Event):
-    """ Subclass of Event for events which deal with an EV such as Plugin and Unplug events.
+    """ Subclass of Event for events which deal with an EV such as Plugin and Unplug
+    events.
 
     Args:
         timestamp (int): See Event.
-        ev (EV): The EV which will be plugged in.
+        ev (EV): The EV associated with this event.
     """
+    ev: EV
 
-    def __init__(self, timestamp, ev):
+    def __init__(self, timestamp: int, ev: EV) -> None:
         super().__init__(timestamp)
         self.ev = ev
 
@@ -126,7 +138,7 @@ class PluginEvent(EVEvent):
         ev (EV): The EV which will be plugged in.
     """
 
-    def __init__(self, timestamp, ev):
+    def __init__(self, timestamp: int, ev: EV) -> None:
         super().__init__(timestamp, ev)
         self.event_type = "Plugin"
         self.precedence = 10
@@ -140,7 +152,7 @@ class UnplugEvent(EVEvent):
         ev (EV): The EV which will be unplugged.
     """
 
-    def __init__(self, timestamp, ev):
+    def __init__(self, timestamp: int, ev: EV) -> None:
         super().__init__(timestamp, ev)
         self.event_type = "Unplug"
         self.precedence = 0
@@ -149,7 +161,7 @@ class UnplugEvent(EVEvent):
 class RecomputeEvent(Event):
     """ Subclass of Event for when the algorithm should be recomputed."""
 
-    def __init__(self, timestamp):
+    def __init__(self, timestamp: int) -> None:
         super().__init__(timestamp)
         self.event_type = "Recompute"
         self.precedence = 20

--- a/acnportal/acnsim/models/battery.py
+++ b/acnportal/acnsim/models/battery.py
@@ -316,7 +316,9 @@ class Linear2StageBattery(Battery):
         if self._soc < self._transition_soc:
             charge_power = min([pilot * voltage / 1000, self._max_power, rate_to_full])
             if self._noise_level > 0:
-                charge_power = max(charge_power - abs(np.random.normal(0, self._noise_level)), 0)
+                charge_power = max(
+                    charge_power - abs(np.random.normal(0, self._noise_level)), 0
+                )
         else:
             charge_power = min(
                 [
@@ -326,7 +328,12 @@ class Linear2StageBattery(Battery):
                 ]
             )
             if self._noise_level > 0:
-                charge_power = min(max(charge_power + np.random.normal(0, self._noise_level), 0), pilot * voltage / 1000, self._max_power, rate_to_full)
+                charge_power = min(
+                    max(charge_power + np.random.normal(0, self._noise_level), 0),
+                    pilot * voltage / 1000,
+                    self._max_power,
+                    rate_to_full,
+                )
                 # ensure that noise does not cause the battery to violate any hard limits.
                 charge_power = min(
                     [

--- a/acnportal/acnsim/simulator.py
+++ b/acnportal/acnsim/simulator.py
@@ -1,9 +1,7 @@
 import copy
 from datetime import datetime
-from typing import Optional, Dict, Any, Tuple
+from typing import Dict
 
-import pandas as pd
-import numpy as np
 import warnings
 import json
 
@@ -204,7 +202,7 @@ class Simulator(BaseSimObj):
         """ Process an event and take appropriate actions.
 
         Args:
-            event (Event): Event to be processed.
+            event (EVEvent): Event to be processed.
 
         Returns:
             None
@@ -213,16 +211,12 @@ class Simulator(BaseSimObj):
             self._print("Plugin Event...")
             self.network.plugin(event.ev)
             self.ev_history[event.ev.session_id] = event.ev
-            self.event_queue.add_event(
-                UnplugEvent(
-                    event.ev.departure, event.ev.station_id, event.ev.session_id
-                )
-            )
+            self.event_queue.add_event(UnplugEvent(event.ev.departure, event.ev))
             self._resolve = True
             self._last_schedule_update = event.timestamp
         elif event.event_type == "Unplug":
             self._print("Unplug Event...")
-            self.network.unplug(event.station_id, event.session_id)
+            self.network.unplug(event.ev.station_id, event.ev.session_id)
             self._resolve = True
             self._last_schedule_update = event.timestamp
         elif event.event_type == "Recompute":

--- a/acnportal/acnsim/simulator.py
+++ b/acnportal/acnsim/simulator.py
@@ -202,7 +202,7 @@ class Simulator(BaseSimObj):
         """ Process an event and take appropriate actions.
 
         Args:
-            event (EVEvent): Event to be processed.
+            event (Event): Event to be processed.
 
         Returns:
             None

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,5 @@ setuptools.setup(
         "pytz",
         "typing_extensions",
     ],
-    extras_require={
-        "all": ["scikit-learn"],
-        "scikit-learn": ["scikit-learn"]
-    }
+    extras_require={"all": ["scikit-learn"], "scikit-learn": ["scikit-learn"]},
 )

--- a/tests/old_unplug.json
+++ b/tests/old_unplug.json
@@ -1,0 +1,20 @@
+{
+  "id": "140258042267600",
+  "context_dict": {
+    "140258042267600": {
+      "class": "acnportal.acnsim.events.event.UnplugEvent",
+      "attributes": {
+        "timestamp": 11,
+        "event_type": "Unplug",
+        "precedence": 0,
+        "station_id": "PS-001",
+        "session_id": "EV-001"
+      }
+    }
+  },
+  "version": "0.2.2",
+  "dependency_versions": {
+    "numpy": "1.19.1",
+    "pandas": "1.1.0"
+  }
+}

--- a/tests/test_json_io.py
+++ b/tests/test_json_io.py
@@ -273,7 +273,8 @@ class TestJSONIO(TestCase):
         self.assertEqual(getattr(getattr(event_loaded, "ev"), "_session_id"), "EV-001")
 
     def test_unplug_event_json(self):
-        _ = self._obj_compare_helper(self.unplug_event)
+        event_loaded = self._obj_compare_helper(self.unplug_event)
+        self.assertEqual(getattr(getattr(event_loaded, "ev"), "_session_id"), "EV-001")
 
     def test_recompute_event_json(self):
         _ = self._obj_compare_helper(self.recompute_event1)

--- a/tests/test_json_io.py
+++ b/tests/test_json_io.py
@@ -5,8 +5,8 @@ from unittest import TestCase
 from acnportal import acnsim
 from acnportal.algorithms import BaseAlgorithm, UncontrolledCharging
 from acnportal.acnsim.base import ErrorAllWrapper
-from .serialization_extensions import NamedEvent, DefaultNamedEvent
-from .serialization_extensions import SetAttrEvent, BatteryListEvent
+from tests.serialization_extensions import NamedEvent, DefaultNamedEvent
+from tests.serialization_extensions import SetAttrEvent, BatteryListEvent
 
 import os
 import numpy as np
@@ -87,7 +87,7 @@ class TestJSONIO(TestCase):
         # Events
         cls.event = acnsim.Event(0)
         cls.plugin_event1 = acnsim.PluginEvent(10, cls.ev1)
-        cls.unplug_event = acnsim.UnplugEvent(20, "PS-001", "EV-001")
+        cls.unplug_event = acnsim.UnplugEvent(20, cls.ev1)
         cls.recompute_event1 = acnsim.RecomputeEvent(30)
         cls.plugin_event2 = acnsim.PluginEvent(40, cls.ev2)
         cls.plugin_event3 = acnsim.PluginEvent(50, cls.ev3)
@@ -200,13 +200,7 @@ class TestJSONIO(TestCase):
             ],
             "Event": ["timestamp", "event_type", "precedence"],
             "PluginEvent": ["timestamp", "event_type", "precedence"],
-            "UnplugEvent": [
-                "timestamp",
-                "event_type",
-                "precedence",
-                "station_id",
-                "session_id",
-            ],
+            "UnplugEvent": ["timestamp", "event_type", "precedence"],
             "RecomputeEvent": ["timestamp", "event_type", "precedence"],
             "EventQueue": ["_timestep"],
             "ChargingNetwork": [


### PR DESCRIPTION
…station_id.

UnplugEvent should contain an EV object so that it can properly handle if the EV object is updated throughout the life of the session. 

Currently, UnplugEvent contained the session_id and station_id for the EV, but this does not handle the case when the station is updated.