### PR TITLE
Refactor test_interface to add constraints using built-in functions.

### DIFF
--- a/acnportal/acnsim/tests/test_interface.py
+++ b/acnportal/acnsim/tests/test_interface.py
@@ -12,6 +12,7 @@ from acnportal.acnsim import (
     InvalidScheduleError,
     FiniteRatesEVSE,
     DeadbandEVSE,
+    Current,
 )
 from acnportal.acnsim.interface import SessionInfo, InfrastructureInfo, Constraint
 from acnportal.acnsim.models import EVSE
@@ -272,9 +273,8 @@ class TestInterface(TestCase):
         self.allowable_rates: List[int] = [0, 8, 16, 24, 32]
         evse4: FiniteRatesEVSE = FiniteRatesEVSE("PS-004", self.allowable_rates)
         self.network.register_evse(evse4, 120, -30)
-        self.network.constraint_matrix = np.eye(4)
-        self.network.magnitudes = np.ones((4, 1))
-        self.network.constraint_index = ["C1", "C2", "C3", "C4"]
+        for i, station_id in enumerate(self.network.station_ids):
+            self.network.add_constraint(Current(station_id), 1, f"C{i+1}")
 
     def test_init(self) -> None:
         self.assertIs(self.interface._simulator, self.simulator)


### PR DESCRIPTION
Previously, network constraints were specified by directly setting constraint_matrix, magnitudes, etc. attributes of ChargingNetwork. We can avoid the incorrect setting of these attributes by using the built-in add_constraint functionality instead.

This PR fixes a failing test in the gym-acnportal package and involves no change in ACN-Sim functionality.