### PR TITLE
Sync dev with master (v0.3.3 + pandas/Python version updates)

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -11,11 +11,10 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10, 3.11]
 
     steps:
         - uses: actions/checkout@v2

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, 3.10, 3.11]
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
         - uses: actions/checkout@v2

--- a/acnportal/acnsim/base.py
+++ b/acnportal/acnsim/base.py
@@ -38,7 +38,7 @@ else:
     )
 
     # compression keywords and compression
-    CompressionDict = dict[str, Any]
+    CompressionDict = Dict[str, Any]
     CompressionOptions = Optional[
         Union[
             Literal["infer", "gzip", "bz2", "zip", "xz", "zstd", "tar"], CompressionDict

--- a/acnportal/acnsim/base.py
+++ b/acnportal/acnsim/base.py
@@ -14,7 +14,7 @@ from pydoc import locate
 import warnings
 import pkg_resources
 import pandas
-from pandas.io.common import stringify_path, get_handle, get_filepath_or_buffer
+from pandas.io.common import stringify_path, get_handle, _get_filepath_or_buffer
 import numpy
 
 __NOT_SERIALIZED_FLAG__ = "__NOT_SERIALIZED__"
@@ -160,7 +160,7 @@ class BaseSimObj:
             )
         path_or_buf = stringify_path(path_or_buf)
         if isinstance(path_or_buf, str):
-            fh, _ = get_handle(path_or_buf, "w")
+            fh = get_handle(path_or_buf, "w").handle
             try:
                 json.dump(json_serializable_data, fh, cls=NpEncoder)
                 # Add a newline to the EOF.
@@ -421,7 +421,9 @@ class BaseSimObj:
         """
         # The code here is from pandas 1.0.1, io.json.from_json(), with
         # modifications.
-        filepath_or_buffer, _, _, should_close = get_filepath_or_buffer(path_or_buf)
+        ioargs = _get_filepath_or_buffer(path_or_buf)
+        filepath_or_buffer = ioargs.filepath_or_buffer
+        should_close = ioargs.should_close
 
         exists = False
         if isinstance(filepath_or_buffer, str):
@@ -431,7 +433,7 @@ class BaseSimObj:
                 pass
 
         if exists:
-            filepath_or_buffer, _ = get_handle(filepath_or_buffer, "r")
+            filepath_or_buffer = get_handle(filepath_or_buffer, "r").handle
             should_close = True
 
         if isinstance(filepath_or_buffer, str):

--- a/acnportal/acnsim/network/charging_network.py
+++ b/acnportal/acnsim/network/charging_network.py
@@ -255,7 +255,7 @@ class ChargingNetwork(BaseSimObj):
         if pd.__version__ > "1.4.0":
             if len(constraint_frame) == 0:
                 constraint_frame_ = current.to_frame().T
-                for col in constraint_frame_:
+                for col in constraint_frame:
                     if col not in constraint_frame_:
                         constraint_frame_[col] = 0
                 constraint_frame = constraint_frame_

--- a/acnportal/acnsim/network/charging_network.py
+++ b/acnportal/acnsim/network/charging_network.py
@@ -97,7 +97,7 @@ class ChargingNetwork(BaseSimObj):
 
     @property
     def current_charging_rates(self) -> np.ndarray:
-        """ Return the current actual charging rate of all EVSEs in the network. If
+        """Return the current actual charging rate of all EVSEs in the network. If
         no EV is attached to a given EVSE, that EVSE's charging rate is 0. In the
         returned array, the charging rates are given in the same order as the list of
         EVSEs given by station_ids
@@ -115,7 +115,7 @@ class ChargingNetwork(BaseSimObj):
 
     @property
     def station_ids(self) -> List[str]:
-        """ Return the IDs of all registered EVSEs.
+        """Return the IDs of all registered EVSEs.
 
         Returns:
             List[str]: List of all registered EVSE IDs.
@@ -124,7 +124,7 @@ class ChargingNetwork(BaseSimObj):
 
     @property
     def active_evs(self) -> List[EV]:
-        """ Return all EVs which are connected to an EVSE and which are not already
+        """Return all EVs which are connected to an EVSE and which are not already
         fully charged.
 
         Returns:
@@ -138,7 +138,7 @@ class ChargingNetwork(BaseSimObj):
 
     @property
     def active_station_ids(self) -> List[str]:
-        """ Return IDs for all stations which have an active EV attached.
+        """Return IDs for all stations which have an active EV attached.
 
         Returns:
             List[str]: List of the station_id of all stations which have an
@@ -152,7 +152,7 @@ class ChargingNetwork(BaseSimObj):
 
     @property
     def voltages(self) -> Dict[str, float]:
-        """ Return dictionary of voltages for all EVSEs in the network.
+        """Return dictionary of voltages for all EVSEs in the network.
 
         Returns:
             Dict[str, float]: Dictionary mapping EVSE ids their input voltage. [V]
@@ -163,7 +163,7 @@ class ChargingNetwork(BaseSimObj):
 
     @property
     def phase_angles(self) -> Dict[str, float]:
-        """ Return dictionary of phase angles for all EVSEs in the network.
+        """Return dictionary of phase angles for all EVSEs in the network.
 
         Returns:
             Dict[str, float]: Dictionary mapping EVSE ids their input phase angle. [
@@ -175,7 +175,7 @@ class ChargingNetwork(BaseSimObj):
         }
 
     def register_evse(self, evse: BaseEVSE, voltage: float, phase_angle: float) -> None:
-        """ Register an EVSE with the network so it will be accessible to the rest of
+        """Register an EVSE with the network so it will be accessible to the rest of
         the simulation. This can only be called before any constraints have been
         registered in order to prevent dimensionality mismatch between the EVSE list
         and the
@@ -202,7 +202,7 @@ class ChargingNetwork(BaseSimObj):
         _ = self._update_info_store()
 
     def constraints_as_df(self) -> pd.DataFrame:
-        """ Returns the network constraints in a pandas DataFrame.
+        """Returns the network constraints in a pandas DataFrame.
 
         The index is the constraint IDs, and the columns are station IDs. The
         magnitudes (constraint limits) must be accessed separately.
@@ -219,7 +219,7 @@ class ChargingNetwork(BaseSimObj):
     def add_constraint(
         self, current: Current, limit: float, name: Optional[str] = None
     ) -> None:
-        """ Add an additional constraint to the constraint DataFrame.
+        """Add an additional constraint to the constraint DataFrame.
 
         Args:
             current (Current): Aggregate current which is constrained.
@@ -251,7 +251,27 @@ class ChargingNetwork(BaseSimObj):
         # Make a DataFrame for the constraint matrix for easy addition of the new
         # constraint
         constraint_frame: pd.DataFrame = self.constraints_as_df()
-        constraint_frame = constraint_frame.append(current).fillna(0)
+
+        if pd.__version__ > "1.4.0":
+            if len(constraint_frame) == 0:
+                constraint_frame_ = current.to_frame().T
+                for col in constraint_frame_:
+                    if col not in constraint_frame_:
+                        constraint_frame_[col] = 0
+                constraint_frame = constraint_frame_
+            else:
+                constraint_frame = pd.concat(
+                    [constraint_frame, current.to_frame().T]
+                ).fillna(0)
+        else:
+            constraint_frame = constraint_frame.append(current).fillna(0)
+
+            warnings.warn(
+                f"Compatability with pandas <=1.4.0 may not be supported in "
+                f"a future version of acnportal.",
+                DeprecationWarning,
+            )
+
         # Maintain a list of constraint ids for use with constraint_current.
         self.constraint_index = list(constraint_frame.index)
         # Update the numpy matrix of constraints by reconstructing it from
@@ -263,7 +283,7 @@ class ChargingNetwork(BaseSimObj):
         _ = self._update_info_store()
 
     def remove_constraint(self, name: str) -> None:
-        """ Remove a network constraint.
+        """Remove a network constraint.
 
         Args:
             name (str): Name of constraint to remove.
@@ -283,7 +303,7 @@ class ChargingNetwork(BaseSimObj):
     def update_constraint(
         self, name: str, current: Current, limit: float, new_name: Optional[str] = None
     ) -> None:
-        """ Update a network constraint with a new aggregate current, limit, and name.
+        """Update a network constraint with a new aggregate current, limit, and name.
 
         Args:
             name (str): Name of constraint to update.
@@ -304,7 +324,7 @@ class ChargingNetwork(BaseSimObj):
         _ = self._update_info_store()
 
     def plugin(self, ev: EV, station_id: str = None) -> None:
-        """ Attach EV to a specific EVSE.
+        """Attach EV to a specific EVSE.
 
         Args:
             ev (EV): EV object which will be attached to the EVSE.
@@ -329,7 +349,7 @@ class ChargingNetwork(BaseSimObj):
             raise KeyError("Station {0} not found.".format(ev.station_id))
 
     def unplug(self, station_id: str, session_id: str = None) -> None:
-        """ Detach EV from a specific EVSE.
+        """Detach EV from a specific EVSE.
 
         Args:
             station_id (str): ID of the EVSE.
@@ -366,7 +386,7 @@ class ChargingNetwork(BaseSimObj):
             raise KeyError("Station {0} not found.".format(station_id))
 
     def get_ev(self, station_id: str) -> EV:
-        """ Return the EV attached to the specified EVSE.
+        """Return the EV attached to the specified EVSE.
 
         Args:
             station_id (str): ID of the EVSE.
@@ -381,7 +401,7 @@ class ChargingNetwork(BaseSimObj):
             raise KeyError("Station {0} not found.".format(station_id))
 
     def update_pilots(self, pilots: np.ndarray, i: int, period: float) -> None:
-        """ Update the pilot signal sent to each EV. Also triggers the EVs to charge
+        """Update the pilot signal sent to each EV. Also triggers the EVs to charge
         at the specified rate.
 
         Note that if a pilot is not sent to an EVSE the associated EV WILL NOT charge
@@ -414,7 +434,7 @@ class ChargingNetwork(BaseSimObj):
         time_indices: Optional[List[int]] = None,
         linear: bool = False,
     ):
-        """ Return the aggregate currents subject to the given constraints. If
+        """Return the aggregate currents subject to the given constraints. If
         constraints=None, return all aggregate currents.
 
         Args:
@@ -470,7 +490,7 @@ class ChargingNetwork(BaseSimObj):
         violation_tolerance: Optional[float] = None,
         relative_tolerance: Optional[float] = None,
     ) -> bool:
-        """ Return if a set of current magnitudes for each load are feasible.
+        """Return if a set of current magnitudes for each load are feasible.
 
         For a given constraint, the larger of the violation_tolerance
         and relative_tolerance is used to evaluate feasibility.
@@ -521,13 +541,13 @@ class ChargingNetwork(BaseSimObj):
         )
 
     def post_charging_update(self):
-        """ Hook to define actions to take after the charging update. """
+        """Hook to define actions to take after the charging update."""
         pass
 
     def _to_dict(
         self, context_dict: Optional[Dict[str, Any]] = None
     ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
-        """ Implements BaseSimObj._to_dict. """
+        """Implements BaseSimObj._to_dict."""
 
         attribute_dict = {}
         # Serialize non-nested attributes.
@@ -568,7 +588,7 @@ class ChargingNetwork(BaseSimObj):
         context_dict: Dict[str, Any],
         loaded_dict: Optional[Dict[str, BaseSimObj]] = None,
     ) -> Tuple[BaseSimObj, Dict[str, BaseSimObj]]:
-        """ Implements BaseSimObj._from_dict. """
+        """Implements BaseSimObj._from_dict."""
         out_obj = cls(
             violation_tolerance=attribute_dict["violation_tolerance"],
             relative_tolerance=attribute_dict["relative_tolerance"],
@@ -624,10 +644,10 @@ class ChargingNetwork(BaseSimObj):
 
 
 class StationOccupiedError(Exception):
-    """ Exception which is raised when trying to add an EV to an EVSE which is
-    already occupied. """
+    """Exception which is raised when trying to add an EV to an EVSE which is
+    already occupied."""
 
 
 class EVSERegistrationError(Exception):
-    """ Exception which is raised when trying to add an EVSE to the network after
-    constraints have already been added. """
+    """Exception which is raised when trying to add an EVSE to the network after
+    constraints have already been added."""

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setuptools.setup(
     ],
     install_requires=[
         "numpy",
-        "pandas >= 1.1.0, < 1.2.0",
+        "pandas",
         "matplotlib",
         "requests",
         "pytz",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 setuptools.setup(
     name="acnportal",
-    version="0.3.2",
+    version="0.3.3",
     author="Zachary Lee, Sunash Sharma",
     author_email="ev-help@caltech.edu",
     url="https://github.com/zach401/acnportal",


### PR DESCRIPTION
## Summary

`dev` was missing 16 commits that had been merged directly into `master` since the last sync. This PR brings `dev` up to date with `master`.

### Commits included from master

- **Version bump to 0.3.3** (PR #118)
- **Pandas v2 upgrade** (PR #116) — `_get_filepath_or_buffer` adaptation, JSON serialization fix, constraint frame zero-value initialization, `Dict` from `typing` for Python 3.8 backward compatibility
- **Python version support update** (PR #117) — Drop Python 3.6/3.7, add 3.10/3.11 in GitHub Actions; define versions as strings in GHA config

### Merge conflict resolution

Three files had conflicts, all resolved in favor of master's intentional changes:

| File | Conflict | Resolution |
|------|----------|------------|
| `acnportal/acnsim/base.py` | `dict[str, Any]` vs `Dict[str, Any]` | Took `Dict` (Python 3.8 compat) |
| `acnportal/acnsim/base.py` | `Optional[Dict]` return types on `_to_dict`/`_from_dict` | Removed `Optional` (matches master's tightened types) |
| `acnportal/acnsim/network/charging_network.py` | Same `Optional` return type + docstring whitespace | Same as above |

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZc8xBemQYftSb1duhxzHz)_